### PR TITLE
ENH: Rotated label for evRangeCnst

### DIFF
--- a/main.ui
+++ b/main.ui
@@ -435,29 +435,21 @@
               </property>
               <property name="font">
                <font>
+                <family>Arial</family>
                 <pointsize>8</pointsize>
                </font>
               </property>
               <property name="toolTip">
                <string/>
               </property>
-              <property name="styleSheet">
-               <string notr="true">border: 1px solid black;</string>
-              </property>
               <property name="text">
                <string>25000</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-              </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
               <property name="channel" stdset="0">
                <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[15:15]</string>
-              </property>
-              <property name="displayFormat" stdset="0">
-               <enum>PyDMLabel::Decimal</enum>
               </property>
              </widget>
             </item>
@@ -468,29 +460,21 @@
               </property>
               <property name="font">
                <font>
+                <family>Arial</family>
                 <pointsize>8</pointsize>
                </font>
               </property>
               <property name="toolTip">
                <string/>
               </property>
-              <property name="styleSheet">
-               <string notr="true">border: 1px solid black;</string>
-              </property>
               <property name="text">
                <string>25000</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-              </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
               <property name="channel" stdset="0">
                <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[14:14]</string>
-              </property>
-              <property name="displayFormat" stdset="0">
-               <enum>PyDMLabel::Decimal</enum>
               </property>
              </widget>
             </item>
@@ -501,29 +485,21 @@
               </property>
               <property name="font">
                <font>
+                <family>Arial</family>
                 <pointsize>8</pointsize>
                </font>
               </property>
               <property name="toolTip">
                <string/>
               </property>
-              <property name="styleSheet">
-               <string notr="true">border: 1px solid black;</string>
-              </property>
               <property name="text">
                <string>25000</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-              </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
               <property name="channel" stdset="0">
                <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[13:13]</string>
-              </property>
-              <property name="displayFormat" stdset="0">
-               <enum>PyDMLabel::Decimal</enum>
               </property>
              </widget>
             </item>
@@ -534,29 +510,21 @@
               </property>
               <property name="font">
                <font>
+                <family>Arial</family>
                 <pointsize>8</pointsize>
                </font>
               </property>
               <property name="toolTip">
                <string/>
               </property>
-              <property name="styleSheet">
-               <string notr="true">border: 1px solid black;</string>
-              </property>
               <property name="text">
                <string>25000</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-              </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
               <property name="channel" stdset="0">
                <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[12:12]</string>
-              </property>
-              <property name="displayFormat" stdset="0">
-               <enum>PyDMLabel::Decimal</enum>
               </property>
              </widget>
             </item>
@@ -567,29 +535,21 @@
               </property>
               <property name="font">
                <font>
+                <family>Arial</family>
                 <pointsize>8</pointsize>
                </font>
               </property>
               <property name="toolTip">
                <string/>
               </property>
-              <property name="styleSheet">
-               <string notr="true">border: 1px solid black;</string>
-              </property>
               <property name="text">
                <string>25000</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-              </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
               <property name="channel" stdset="0">
                <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[11:11]</string>
-              </property>
-              <property name="displayFormat" stdset="0">
-               <enum>PyDMLabel::Decimal</enum>
               </property>
              </widget>
             </item>
@@ -600,29 +560,21 @@
               </property>
               <property name="font">
                <font>
+                <family>Arial</family>
                 <pointsize>8</pointsize>
                </font>
               </property>
               <property name="toolTip">
                <string/>
               </property>
-              <property name="styleSheet">
-               <string notr="true">border: 1px solid black;</string>
-              </property>
               <property name="text">
                <string>25000</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-              </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
               <property name="channel" stdset="0">
                <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[10:10]</string>
-              </property>
-              <property name="displayFormat" stdset="0">
-               <enum>PyDMLabel::Decimal</enum>
               </property>
              </widget>
             </item>
@@ -633,29 +585,21 @@
               </property>
               <property name="font">
                <font>
+                <family>Arial</family>
                 <pointsize>8</pointsize>
                </font>
               </property>
               <property name="toolTip">
                <string/>
               </property>
-              <property name="styleSheet">
-               <string notr="true">border: 1px solid black;</string>
-              </property>
               <property name="text">
                <string>25000</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-              </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
               <property name="channel" stdset="0">
                <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[9:9]</string>
-              </property>
-              <property name="displayFormat" stdset="0">
-               <enum>PyDMLabel::Decimal</enum>
               </property>
              </widget>
             </item>
@@ -666,29 +610,21 @@
               </property>
               <property name="font">
                <font>
+                <family>Arial</family>
                 <pointsize>8</pointsize>
                </font>
               </property>
               <property name="toolTip">
                <string/>
               </property>
-              <property name="styleSheet">
-               <string notr="true">border: 1px solid black;</string>
-              </property>
               <property name="text">
                <string>25000</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-              </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
               <property name="channel" stdset="0">
                <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[8:8]</string>
-              </property>
-              <property name="displayFormat" stdset="0">
-               <enum>PyDMLabel::Decimal</enum>
               </property>
              </widget>
             </item>
@@ -699,29 +635,21 @@
               </property>
               <property name="font">
                <font>
+                <family>Arial</family>
                 <pointsize>8</pointsize>
                </font>
               </property>
               <property name="toolTip">
                <string/>
               </property>
-              <property name="styleSheet">
-               <string notr="true">border: 1px solid black;</string>
-              </property>
               <property name="text">
                <string>25000</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-              </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
               <property name="channel" stdset="0">
                <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[7:7]</string>
-              </property>
-              <property name="displayFormat" stdset="0">
-               <enum>PyDMLabel::Decimal</enum>
               </property>
              </widget>
             </item>
@@ -732,29 +660,21 @@
               </property>
               <property name="font">
                <font>
+                <family>Arial</family>
                 <pointsize>8</pointsize>
                </font>
               </property>
               <property name="toolTip">
                <string/>
               </property>
-              <property name="styleSheet">
-               <string notr="true">border: 1px solid black;</string>
-              </property>
               <property name="text">
                <string>25000</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-              </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
               <property name="channel" stdset="0">
                <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[6:6]</string>
-              </property>
-              <property name="displayFormat" stdset="0">
-               <enum>PyDMLabel::Decimal</enum>
               </property>
              </widget>
             </item>
@@ -765,29 +685,21 @@
               </property>
               <property name="font">
                <font>
+                <family>Arial</family>
                 <pointsize>8</pointsize>
                </font>
               </property>
               <property name="toolTip">
                <string/>
               </property>
-              <property name="styleSheet">
-               <string notr="true">border: 1px solid black;</string>
-              </property>
               <property name="text">
                <string>25000</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-              </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
               <property name="channel" stdset="0">
                <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[5:5]</string>
-              </property>
-              <property name="displayFormat" stdset="0">
-               <enum>PyDMLabel::Decimal</enum>
               </property>
              </widget>
             </item>
@@ -798,29 +710,21 @@
               </property>
               <property name="font">
                <font>
+                <family>Arial</family>
                 <pointsize>8</pointsize>
                </font>
               </property>
               <property name="toolTip">
                <string/>
               </property>
-              <property name="styleSheet">
-               <string notr="true">border: 1px solid black;</string>
-              </property>
               <property name="text">
                <string>25000</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-              </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
               <property name="channel" stdset="0">
                <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[4:4]</string>
-              </property>
-              <property name="displayFormat" stdset="0">
-               <enum>PyDMLabel::Decimal</enum>
               </property>
              </widget>
             </item>
@@ -831,29 +735,21 @@
               </property>
               <property name="font">
                <font>
+                <family>Arial</family>
                 <pointsize>8</pointsize>
                </font>
               </property>
               <property name="toolTip">
                <string/>
               </property>
-              <property name="styleSheet">
-               <string notr="true">border: 1px solid black;</string>
-              </property>
               <property name="text">
                <string>25000</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-              </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
               <property name="channel" stdset="0">
                <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[3:3]</string>
-              </property>
-              <property name="displayFormat" stdset="0">
-               <enum>PyDMLabel::Decimal</enum>
               </property>
              </widget>
             </item>
@@ -864,29 +760,21 @@
               </property>
               <property name="font">
                <font>
+                <family>Arial</family>
                 <pointsize>8</pointsize>
                </font>
               </property>
               <property name="toolTip">
                <string/>
               </property>
-              <property name="styleSheet">
-               <string notr="true">border: 1px solid black;</string>
-              </property>
               <property name="text">
                <string>25000</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-              </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
               <property name="channel" stdset="0">
                <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[2:2]</string>
-              </property>
-              <property name="displayFormat" stdset="0">
-               <enum>PyDMLabel::Decimal</enum>
               </property>
              </widget>
             </item>
@@ -897,29 +785,21 @@
               </property>
               <property name="font">
                <font>
+                <family>Arial</family>
                 <pointsize>8</pointsize>
                </font>
               </property>
               <property name="toolTip">
                <string/>
               </property>
-              <property name="styleSheet">
-               <string notr="true">border: 1px solid black;</string>
-              </property>
               <property name="text">
                <string>25000</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-              </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
               <property name="channel" stdset="0">
                <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[1:1]</string>
-              </property>
-              <property name="displayFormat" stdset="0">
-               <enum>PyDMLabel::Decimal</enum>
               </property>
              </widget>
             </item>
@@ -930,29 +810,21 @@
               </property>
               <property name="font">
                <font>
+                <family>Arial</family>
                 <pointsize>8</pointsize>
                </font>
               </property>
               <property name="toolTip">
                <string/>
               </property>
-              <property name="styleSheet">
-               <string notr="true">border: 1px solid black;</string>
-              </property>
               <property name="text">
                <string>25000</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-              </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
               <property name="channel" stdset="0">
                <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[0:0]</string>
-              </property>
-              <property name="displayFormat" stdset="0">
-               <enum>PyDMLabel::Decimal</enum>
               </property>
              </widget>
             </item>

--- a/main.ui
+++ b/main.ui
@@ -442,10 +442,13 @@
                <string/>
               </property>
               <property name="styleSheet">
-               <string notr="true"/>
+               <string notr="true">border: 1px solid black;</string>
               </property>
               <property name="text">
                <string>25000</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
               </property>
               <property name="precisionFromPV" stdset="0">
                <bool>true</bool>
@@ -477,6 +480,9 @@
               <property name="text">
                <string>25000</string>
               </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+              </property>
               <property name="precisionFromPV" stdset="0">
                <bool>true</bool>
               </property>
@@ -506,6 +512,9 @@
               </property>
               <property name="text">
                <string>25000</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
               </property>
               <property name="precisionFromPV" stdset="0">
                <bool>true</bool>
@@ -537,6 +546,9 @@
               <property name="text">
                <string>25000</string>
               </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+              </property>
               <property name="precisionFromPV" stdset="0">
                <bool>true</bool>
               </property>
@@ -566,6 +578,9 @@
               </property>
               <property name="text">
                <string>25000</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
               </property>
               <property name="precisionFromPV" stdset="0">
                <bool>true</bool>
@@ -597,6 +612,9 @@
               <property name="text">
                <string>25000</string>
               </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+              </property>
               <property name="precisionFromPV" stdset="0">
                <bool>true</bool>
               </property>
@@ -626,6 +644,9 @@
               </property>
               <property name="text">
                <string>25000</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
               </property>
               <property name="precisionFromPV" stdset="0">
                <bool>true</bool>
@@ -657,6 +678,9 @@
               <property name="text">
                <string>25000</string>
               </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+              </property>
               <property name="precisionFromPV" stdset="0">
                <bool>true</bool>
               </property>
@@ -686,6 +710,9 @@
               </property>
               <property name="text">
                <string>25000</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
               </property>
               <property name="precisionFromPV" stdset="0">
                <bool>true</bool>
@@ -717,6 +744,9 @@
               <property name="text">
                <string>25000</string>
               </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+              </property>
               <property name="precisionFromPV" stdset="0">
                <bool>true</bool>
               </property>
@@ -746,6 +776,9 @@
               </property>
               <property name="text">
                <string>25000</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
               </property>
               <property name="precisionFromPV" stdset="0">
                <bool>true</bool>
@@ -777,6 +810,9 @@
               <property name="text">
                <string>25000</string>
               </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+              </property>
               <property name="precisionFromPV" stdset="0">
                <bool>true</bool>
               </property>
@@ -806,6 +842,9 @@
               </property>
               <property name="text">
                <string>25000</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
               </property>
               <property name="precisionFromPV" stdset="0">
                <bool>true</bool>
@@ -837,6 +876,9 @@
               <property name="text">
                <string>25000</string>
               </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+              </property>
               <property name="precisionFromPV" stdset="0">
                <bool>true</bool>
               </property>
@@ -867,6 +909,9 @@
               <property name="text">
                <string>25000</string>
               </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+              </property>
               <property name="precisionFromPV" stdset="0">
                <bool>true</bool>
               </property>
@@ -896,6 +941,9 @@
               </property>
               <property name="text">
                <string>25000</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
               </property>
               <property name="precisionFromPV" stdset="0">
                <bool>true</bool>

--- a/main.ui
+++ b/main.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1520</width>
-    <height>744</height>
+    <width>1486</width>
+    <height>742</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -48,7 +48,7 @@
      <item>
       <widget class="PyDMLabel" name="PyDMLabel_23">
        <property name="enabled">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="toolTip">
         <string/>
@@ -129,7 +129,7 @@
           <item row="4" column="1">
            <widget class="PyDMLabel" name="PyDMLabel_3">
             <property name="enabled">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="toolTip">
              <string/>
@@ -187,7 +187,7 @@
           <item row="3" column="1">
            <widget class="PyDMLabel" name="PyDMLabel_2">
             <property name="enabled">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="toolTip">
              <string/>
@@ -203,7 +203,7 @@
           <item row="7" column="1" colspan="2">
            <widget class="PyDMByteIndicator" name="PyDMByteIndicator_2">
             <property name="enabled">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="maximumSize">
              <size>
@@ -244,7 +244,7 @@
           <item row="2" column="1">
            <widget class="PyDMLabel" name="PyDMLabel">
             <property name="enabled">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="toolTip">
              <string/>
@@ -260,7 +260,7 @@
           <item row="8" column="1" colspan="2">
            <widget class="PyDMByteIndicator" name="PyDMByteIndicator_3">
             <property name="enabled">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="maximumSize">
              <size>
@@ -339,7 +339,7 @@
           <item row="3" column="2">
            <widget class="PyDMLabel" name="PyDMLabel_5">
             <property name="enabled">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="toolTip">
              <string/>
@@ -355,7 +355,7 @@
           <item row="4" column="2">
            <widget class="PyDMLabel" name="PyDMLabel_6">
             <property name="enabled">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="toolTip">
              <string/>
@@ -390,7 +390,7 @@
           <item row="2" column="2">
            <widget class="PyDMLabel" name="PyDMLabel_4">
             <property name="enabled">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="toolTip">
              <string/>
@@ -442,19 +442,16 @@
                <string/>
               </property>
               <property name="styleSheet">
-               <string notr="true">border: 1px solid black;</string>
+               <string notr="true"/>
               </property>
               <property name="text">
-               <string/>
-              </property>
-              <property name="precision" stdset="0">
-               <number>1</number>
+               <string>25000</string>
               </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>false</bool>
+               <bool>true</bool>
               </property>
               <property name="channel" stdset="0">
-               <string>ca://PMPS:LFE:eVRangeCnst_RBV.[15:15]</string>
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[15:15]</string>
               </property>
               <property name="displayFormat" stdset="0">
                <enum>PyDMLabel::Decimal</enum>
@@ -478,16 +475,13 @@
                <string notr="true">border: 1px solid black;</string>
               </property>
               <property name="text">
-               <string/>
-              </property>
-              <property name="precision" stdset="0">
-               <number>1</number>
+               <string>25000</string>
               </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>false</bool>
+               <bool>true</bool>
               </property>
               <property name="channel" stdset="0">
-               <string>ca://PMPS:LFE:eVRangeCnst_RBV.[14:14]</string>
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[14:14]</string>
               </property>
               <property name="displayFormat" stdset="0">
                <enum>PyDMLabel::Decimal</enum>
@@ -511,16 +505,13 @@
                <string notr="true">border: 1px solid black;</string>
               </property>
               <property name="text">
-               <string/>
-              </property>
-              <property name="precision" stdset="0">
-               <number>1</number>
+               <string>25000</string>
               </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>false</bool>
+               <bool>true</bool>
               </property>
               <property name="channel" stdset="0">
-               <string>ca://PMPS:LFE:eVRangeCnst_RBV.[13:13]</string>
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[13:13]</string>
               </property>
               <property name="displayFormat" stdset="0">
                <enum>PyDMLabel::Decimal</enum>
@@ -544,16 +535,13 @@
                <string notr="true">border: 1px solid black;</string>
               </property>
               <property name="text">
-               <string/>
-              </property>
-              <property name="precision" stdset="0">
-               <number>1</number>
+               <string>25000</string>
               </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>false</bool>
+               <bool>true</bool>
               </property>
               <property name="channel" stdset="0">
-               <string>ca://PMPS:LFE:eVRangeCnst_RBV.[12:12]</string>
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[12:12]</string>
               </property>
               <property name="displayFormat" stdset="0">
                <enum>PyDMLabel::Decimal</enum>
@@ -577,16 +565,13 @@
                <string notr="true">border: 1px solid black;</string>
               </property>
               <property name="text">
-               <string/>
-              </property>
-              <property name="precision" stdset="0">
-               <number>1</number>
+               <string>25000</string>
               </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>false</bool>
+               <bool>true</bool>
               </property>
               <property name="channel" stdset="0">
-               <string>ca://PMPS:LFE:eVRangeCnst_RBV.[11:11]</string>
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[11:11]</string>
               </property>
               <property name="displayFormat" stdset="0">
                <enum>PyDMLabel::Decimal</enum>
@@ -610,16 +595,13 @@
                <string notr="true">border: 1px solid black;</string>
               </property>
               <property name="text">
-               <string/>
-              </property>
-              <property name="precision" stdset="0">
-               <number>1</number>
+               <string>25000</string>
               </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>false</bool>
+               <bool>true</bool>
               </property>
               <property name="channel" stdset="0">
-               <string>ca://PMPS:LFE:eVRangeCnst_RBV.[10:10]</string>
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[10:10]</string>
               </property>
               <property name="displayFormat" stdset="0">
                <enum>PyDMLabel::Decimal</enum>
@@ -643,16 +625,13 @@
                <string notr="true">border: 1px solid black;</string>
               </property>
               <property name="text">
-               <string/>
-              </property>
-              <property name="precision" stdset="0">
-               <number>1</number>
+               <string>25000</string>
               </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>false</bool>
+               <bool>true</bool>
               </property>
               <property name="channel" stdset="0">
-               <string>ca://PMPS:LFE:eVRangeCnst_RBV.[9:9]</string>
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[9:9]</string>
               </property>
               <property name="displayFormat" stdset="0">
                <enum>PyDMLabel::Decimal</enum>
@@ -676,16 +655,13 @@
                <string notr="true">border: 1px solid black;</string>
               </property>
               <property name="text">
-               <string/>
-              </property>
-              <property name="precision" stdset="0">
-               <number>1</number>
+               <string>25000</string>
               </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>false</bool>
+               <bool>true</bool>
               </property>
               <property name="channel" stdset="0">
-               <string>ca://PMPS:LFE:eVRangeCnst_RBV.[8:8]</string>
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[8:8]</string>
               </property>
               <property name="displayFormat" stdset="0">
                <enum>PyDMLabel::Decimal</enum>
@@ -709,16 +685,13 @@
                <string notr="true">border: 1px solid black;</string>
               </property>
               <property name="text">
-               <string/>
-              </property>
-              <property name="precision" stdset="0">
-               <number>1</number>
+               <string>25000</string>
               </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>false</bool>
+               <bool>true</bool>
               </property>
               <property name="channel" stdset="0">
-               <string>ca://PMPS:LFE:eVRangeCnst_RBV.[7:7]</string>
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[7:7]</string>
               </property>
               <property name="displayFormat" stdset="0">
                <enum>PyDMLabel::Decimal</enum>
@@ -742,16 +715,13 @@
                <string notr="true">border: 1px solid black;</string>
               </property>
               <property name="text">
-               <string/>
-              </property>
-              <property name="precision" stdset="0">
-               <number>1</number>
+               <string>25000</string>
               </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>false</bool>
+               <bool>true</bool>
               </property>
               <property name="channel" stdset="0">
-               <string>ca://PMPS:LFE:eVRangeCnst_RBV.[6:6]</string>
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[6:6]</string>
               </property>
               <property name="displayFormat" stdset="0">
                <enum>PyDMLabel::Decimal</enum>
@@ -775,16 +745,13 @@
                <string notr="true">border: 1px solid black;</string>
               </property>
               <property name="text">
-               <string/>
-              </property>
-              <property name="precision" stdset="0">
-               <number>1</number>
+               <string>25000</string>
               </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>false</bool>
+               <bool>true</bool>
               </property>
               <property name="channel" stdset="0">
-               <string>ca://PMPS:LFE:eVRangeCnst_RBV.[5:5]</string>
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[5:5]</string>
               </property>
               <property name="displayFormat" stdset="0">
                <enum>PyDMLabel::Decimal</enum>
@@ -808,16 +775,13 @@
                <string notr="true">border: 1px solid black;</string>
               </property>
               <property name="text">
-               <string/>
-              </property>
-              <property name="precision" stdset="0">
-               <number>1</number>
+               <string>25000</string>
               </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>false</bool>
+               <bool>true</bool>
               </property>
               <property name="channel" stdset="0">
-               <string>ca://PMPS:LFE:eVRangeCnst_RBV.[4:4]</string>
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[4:4]</string>
               </property>
               <property name="displayFormat" stdset="0">
                <enum>PyDMLabel::Decimal</enum>
@@ -841,16 +805,13 @@
                <string notr="true">border: 1px solid black;</string>
               </property>
               <property name="text">
-               <string/>
-              </property>
-              <property name="precision" stdset="0">
-               <number>1</number>
+               <string>25000</string>
               </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>false</bool>
+               <bool>true</bool>
               </property>
               <property name="channel" stdset="0">
-               <string>ca://PMPS:LFE:eVRangeCnst_RBV.[3:3]</string>
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[3:3]</string>
               </property>
               <property name="displayFormat" stdset="0">
                <enum>PyDMLabel::Decimal</enum>
@@ -874,16 +835,13 @@
                <string notr="true">border: 1px solid black;</string>
               </property>
               <property name="text">
-               <string/>
-              </property>
-              <property name="precision" stdset="0">
-               <number>1</number>
+               <string>25000</string>
               </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>false</bool>
+               <bool>true</bool>
               </property>
               <property name="channel" stdset="0">
-               <string>ca://PMPS:LFE:eVRangeCnst_RBV.[2:2]</string>
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[2:2]</string>
               </property>
               <property name="displayFormat" stdset="0">
                <enum>PyDMLabel::Decimal</enum>
@@ -907,16 +865,13 @@
                <string notr="true">border: 1px solid black;</string>
               </property>
               <property name="text">
-               <string/>
-              </property>
-              <property name="precision" stdset="0">
-               <number>1</number>
+               <string>25000</string>
               </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>false</bool>
+               <bool>true</bool>
               </property>
               <property name="channel" stdset="0">
-               <string>ca://PMPS:LFE:eVRangeCnst_RBV.[1:1]</string>
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[1:1]</string>
               </property>
               <property name="displayFormat" stdset="0">
                <enum>PyDMLabel::Decimal</enum>
@@ -940,16 +895,13 @@
                <string notr="true">border: 1px solid black;</string>
               </property>
               <property name="text">
-               <string/>
-              </property>
-              <property name="precision" stdset="0">
-               <number>1</number>
+               <string>25000</string>
               </property>
               <property name="precisionFromPV" stdset="0">
-               <bool>false</bool>
+               <bool>true</bool>
               </property>
               <property name="channel" stdset="0">
-               <string>ca://PMPS:LFE:eVRangeCnst_RBV.[0:0]</string>
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[0:0]</string>
               </property>
               <property name="displayFormat" stdset="0">
                <enum>PyDMLabel::Decimal</enum>
@@ -961,7 +913,7 @@
           <item row="9" column="1" colspan="2">
            <widget class="PyDMByteIndicator" name="PyDMByteIndicator_4">
             <property name="enabled">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="maximumSize">
              <size>
@@ -1186,7 +1138,7 @@
          <item row="0" column="1">
           <widget class="PyDMLineEdit" name="PyDMLineEdit">
            <property name="enabled">
-            <bool>true</bool>
+            <bool>false</bool>
            </property>
            <property name="minimumSize">
             <size>
@@ -1227,7 +1179,7 @@
          <item row="1" column="1">
           <widget class="PyDMLineEdit" name="PyDMLineEdit_2">
            <property name="enabled">
-            <bool>true</bool>
+            <bool>false</bool>
            </property>
            <property name="minimumSize">
             <size>
@@ -1268,7 +1220,7 @@
          <item row="2" column="1">
           <widget class="PyDMLineEdit" name="PyDMLineEdit_3">
            <property name="enabled">
-            <bool>true</bool>
+            <bool>false</bool>
            </property>
            <property name="minimumSize">
             <size>
@@ -1309,7 +1261,7 @@
          <item row="3" column="1">
           <widget class="PyDMLineEdit" name="PyDMLineEdit_4">
            <property name="enabled">
-            <bool>true</bool>
+            <bool>false</bool>
            </property>
            <property name="minimumSize">
             <size>
@@ -1337,7 +1289,7 @@
          <item row="4" column="1">
           <widget class="PyDMPushButton" name="PyDMPushButton">
            <property name="enabled">
-            <bool>true</bool>
+            <bool>false</bool>
            </property>
            <property name="minimumSize">
             <size>

--- a/pmps.py
+++ b/pmps.py
@@ -1,8 +1,52 @@
 import yaml
 import webbrowser
 from os import path
-from qtpy import QtCore
+from qtpy import QtCore, QtWidgets, QtGui
 from pydm import Display
+from pydm.widgets import PyDMLabel
+
+
+class VerticalLabel(PyDMLabel):
+    def minimumSizeHint(self):
+        s = QtWidgets.QLabel.minimumSizeHint(self)
+        return QtCore.QSize(s.height(), s.width())
+
+    def sizeHint(self):
+        s = QtWidgets.QLabel.sizeHint(self)
+        return QtCore.QSize(s.height(), s.width())
+
+    def paintEvent(self, ev):
+        painter = QtGui.QPainter(self)
+        painter.setPen(QtCore.Qt.black)
+        painter.setBrush(QtCore.Qt.Dense1Pattern)
+        painter.translate(self.sizeHint().width(), self.sizeHint().height())
+        painter.rotate(270)
+        painter.drawText(0, 0, self.text())
+
+
+def morph_into_vertical(label):
+    def minimumSizeHint(*args, **kwargs):
+        s = QtWidgets.QLabel.minimumSizeHint(label)
+        return QtCore.QSize(s.height(), s.width())
+
+    def sizeHint(*args, **kwargs):
+        s = QtWidgets.QLabel.sizeHint(label)
+        return QtCore.QSize(s.height(), s.width())
+
+    def paintEvent(*args, **kwargs):
+        painter = QtGui.QPainter(label)
+        painter.setPen(QtCore.Qt.black)
+        painter.setBrush(QtCore.Qt.Dense1Pattern)
+        painter.translate(label.sizeHint().width(), label.sizeHint().height())
+        painter.rotate(270)
+        print("Redrawing for label: ", label.objectName())
+        painter.drawText(0, 0, label.text())
+
+    label.minimumSizeHint = minimumSizeHint
+    label.sizeHint = sizeHint
+    label.paintEvent = paintEvent
+    label.update()
+
 
 
 class PMPS(Display):
@@ -38,7 +82,16 @@ class PMPS(Display):
 
         self.ui.btn_open_browser.clicked.connect(self.handle_open_browser)
 
+        self.setup_ev_range_labels()
         self.setup_tabs()
+
+    def setup_ev_range_labels(self):
+        labels = range(7, 23)
+        for l_idx in labels:
+            l = self.findChild(PyDMLabel, "PyDMLabel_{}".format(l_idx))
+            if l is not None:
+                print("L is not None: ", l)
+                morph_into_vertical(l)
 
     def setup_tabs(self):
         # We will do crazy things at this screen... avoid painting

--- a/pmps.py
+++ b/pmps.py
@@ -6,24 +6,6 @@ from pydm import Display
 from pydm.widgets import PyDMLabel
 
 
-class VerticalLabel(PyDMLabel):
-    def minimumSizeHint(self):
-        s = QtWidgets.QLabel.minimumSizeHint(self)
-        return QtCore.QSize(s.height(), s.width())
-
-    def sizeHint(self):
-        s = QtWidgets.QLabel.sizeHint(self)
-        return QtCore.QSize(s.height(), s.width())
-
-    def paintEvent(self, ev):
-        painter = QtGui.QPainter(self)
-        painter.setPen(QtCore.Qt.black)
-        painter.setBrush(QtCore.Qt.Dense1Pattern)
-        painter.translate(self.sizeHint().width(), self.sizeHint().height())
-        painter.rotate(270)
-        painter.drawText(0, 0, self.text())
-
-
 def morph_into_vertical(label):
     def minimumSizeHint(*args, **kwargs):
         s = QtWidgets.QLabel.minimumSizeHint(label)
@@ -35,11 +17,8 @@ def morph_into_vertical(label):
 
     def paintEvent(*args, **kwargs):
         painter = QtGui.QPainter(label)
-        painter.setPen(QtCore.Qt.black)
-        painter.setBrush(QtCore.Qt.Dense1Pattern)
         painter.translate(label.sizeHint().width(), label.sizeHint().height())
         painter.rotate(270)
-        print("Redrawing for label: ", label.objectName())
         painter.drawText(0, 0, label.text())
 
     label.minimumSizeHint = minimumSizeHint
@@ -90,7 +69,6 @@ class PMPS(Display):
         for l_idx in labels:
             l = self.findChild(PyDMLabel, "PyDMLabel_{}".format(l_idx))
             if l is not None:
-                print("L is not None: ", l)
                 morph_into_vertical(l)
 
     def setup_tabs(self):


### PR DESCRIPTION
After change from small values to ginormous ones the data was no longer fitting the UI space so the only reasonable approach was to make the labels vertical.
![image](https://user-images.githubusercontent.com/8185425/87695268-22933e00-c744-11ea-9f2c-e5fd67d3b38b.png)
