### PR TITLE
Preemptive Request Tab updates

### DIFF
--- a/preemptive_requests.py
+++ b/preemptive_requests.py
@@ -37,6 +37,14 @@ class PreemptiveRequests(Display):
                 macros = dict(index=count, P=prefix, ARBITER=arbiter, POOL=pool)
                 widget = PyDMEmbeddedDisplay(parent=reqs_container)
                 widget.macros = json.dumps(macros)
+                channel = f'ca://{prefix}{arbiter}:AP:Entry:{pool}:Live_RBV'
+                rule = {
+                    "name": "PR_Visibility",
+                    "property": "Visible",
+                    "channels": [dict(channel=channel, trigger=True)],
+                    "expression": "ch[0] == 1"
+                }
+                widget.rules = json.dumps([rule])
                 widget.filename = template
                 widget.disconnectWhenHidden = False
                 reqs_container.layout().addWidget(widget)

--- a/templates/preemptive_requests_entry.ui
+++ b/templates/preemptive_requests_entry.ui
@@ -68,7 +68,7 @@
       <string/>
      </property>
      <property name="channel" stdset="0">
-      <string>ca://${P}${ARBITER}:AP:Key:${POOL}:Key_RBV</string>
+      <string>ca://${P}${ARBITER}:AP:Entry:${POOL}:ID_RBV</string>
      </property>
      <property name="displayFormat" stdset="0">
       <enum>PyDMLabel::Hex</enum>

--- a/templates/preemptive_requests_entry.ui
+++ b/templates/preemptive_requests_entry.ui
@@ -323,7 +323,7 @@
       <string/>
      </property>
      <property name="channel" stdset="0">
-      <string>ca://${P}${ARBITER}:AP:Entry:${POOL}:Valid_RBV</string>
+      <string>ca://${P}${ARBITER}:AP:Entry:${POOL}:Live_RBV</string>
      </property>
      <property name="showLabels" stdset="0">
       <bool>false</bool>

--- a/templates/preemptive_requests_header.ui
+++ b/templates/preemptive_requests_header.ui
@@ -73,7 +73,7 @@
         </font>
        </property>
        <property name="text">
-        <string>Entry Key</string>
+        <string>Assertion ID</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
As requested by @slacAWallace:
- Change Entry ID to Assertion ID
- Modify PV for Active status
- Add rule to ensure that only Active preemptive requests are visible.

Creating PR as draft until I can test it at one of the `console` machines with all the proper PVs.