### PR TITLE
ENH: ScrollArea and WordWrap for FF Text

### DIFF
--- a/templates/fastfaults_entry.ui
+++ b/templates/fastfaults_entry.ui
@@ -104,10 +104,7 @@
     </widget>
    </item>
    <item>
-    <widget class="PyDMLabel" name="PyDMLabel_4">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
        <width>350</width>
@@ -120,31 +117,83 @@
        <height>16777215</height>
       </size>
      </property>
-     <property name="toolTip">
-      <string/>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAsNeeded</enum>
      </property>
-     <property name="textFormat">
-      <enum>Qt::AutoText</enum>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAsNeeded</enum>
      </property>
-     <property name="wordWrap">
+     <property name="widgetResizable">
       <bool>true</bool>
      </property>
-     <property name="textInteractionFlags">
-      <set>Qt::TextSelectableByMouse</set>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${P}FFO:${FFO}:FF:${FF}:Info:Path_RBV</string>
-     </property>
-     <property name="displayFormat" stdset="0">
-      <enum>PyDMLabel::String</enum>
-     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>350</width>
+        <height>44</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="PyDMLabel" name="PyDMLabel_4">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>350</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>350</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::AutoText</enum>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://${P}FFO:${FFO}:FF:${FF}:Info:Path_RBV</string>
+         </property>
+         <property name="displayFormat" stdset="0">
+          <enum>PyDMLabel::String</enum>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>
-    <widget class="PyDMLabel" name="PyDMLabel_5">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
+    <widget class="QScrollArea" name="scrollArea_2">
      <property name="minimumSize">
       <size>
        <width>250</width>
@@ -153,25 +202,80 @@
      </property>
      <property name="maximumSize">
       <size>
-       <width>150</width>
+       <width>250</width>
        <height>16777215</height>
       </size>
      </property>
-     <property name="toolTip">
-      <string/>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAsNeeded</enum>
      </property>
-     <property name="wordWrap">
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAsNeeded</enum>
+     </property>
+     <property name="widgetResizable">
       <bool>true</bool>
      </property>
-     <property name="textInteractionFlags">
-      <set>Qt::TextSelectableByMouse</set>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${P}FFO:${FFO}:FF:${FF}:Info:Desc_RBV</string>
-     </property>
-     <property name="displayFormat" stdset="0">
-      <enum>PyDMLabel::String</enum>
-     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents_2">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>250</width>
+        <height>44</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="PyDMLabel" name="PyDMLabel_5">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>250</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>250</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://${P}FFO:${FFO}:FF:${FF}:Info:Desc_RBV</string>
+         </property>
+         <property name="displayFormat" stdset="0">
+          <enum>PyDMLabel::String</enum>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>

--- a/templates/fastfaults_entry.ui
+++ b/templates/fastfaults_entry.ui
@@ -6,20 +6,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1466</width>
+    <width>1470</width>
     <height>60</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>1466</width>
+    <width>1470</width>
     <height>60</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>1466</width>
-    <height>60</height>
+    <width>1470</width>
+    <height>70</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -107,13 +107,13 @@
     <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>350</width>
+       <width>352</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>350</width>
+       <width>352</width>
        <height>16777215</height>
       </size>
      </property>
@@ -132,7 +132,7 @@
         <x>0</x>
         <y>0</y>
         <width>350</width>
-        <height>44</height>
+        <height>58</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -155,18 +155,6 @@
         <widget class="PyDMLabel" name="PyDMLabel_4">
          <property name="enabled">
           <bool>false</bool>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>350</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>350</width>
-           <height>16777215</height>
-          </size>
          </property>
          <property name="toolTip">
           <string/>
@@ -196,13 +184,13 @@
     <widget class="QScrollArea" name="scrollArea_2">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>252</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>252</width>
        <height>16777215</height>
       </size>
      </property>
@@ -221,7 +209,7 @@
         <x>0</x>
         <y>0</y>
         <width>250</width>
-        <height>44</height>
+        <height>58</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -244,18 +232,6 @@
         <widget class="PyDMLabel" name="PyDMLabel_5">
          <property name="enabled">
           <bool>false</bool>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>250</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>250</width>
-           <height>16777215</height>
-          </size>
          </property>
          <property name="toolTip">
           <string/>

--- a/templates/fastfaults_entry.ui
+++ b/templates/fastfaults_entry.ui
@@ -160,6 +160,9 @@
      <property name="toolTip">
       <string/>
      </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
      <property name="textInteractionFlags">
       <set>Qt::TextSelectableByMouse</set>
      </property>

--- a/templates/fastfaults_entry.ui
+++ b/templates/fastfaults_entry.ui
@@ -6,19 +6,19 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1470</width>
+    <width>1420</width>
     <height>60</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>1470</width>
+    <width>1420</width>
     <height>60</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>1470</width>
+    <width>1420</width>
     <height>70</height>
    </size>
   </property>
@@ -107,13 +107,13 @@
     <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>352</width>
+       <width>302</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>352</width>
+       <width>302</width>
        <height>16777215</height>
       </size>
      </property>
@@ -131,7 +131,7 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>350</width>
+        <width>300</width>
         <height>58</height>
        </rect>
       </property>
@@ -155,6 +155,12 @@
         <widget class="PyDMLabel" name="PyDMLabel_4">
          <property name="enabled">
           <bool>false</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
          <property name="toolTip">
           <string/>
@@ -232,6 +238,12 @@
         <widget class="PyDMLabel" name="PyDMLabel_5">
          <property name="enabled">
           <bool>false</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
          <property name="toolTip">
           <string/>

--- a/templates/fastfaults_entry.ui
+++ b/templates/fastfaults_entry.ui
@@ -6,20 +6,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1366</width>
-    <height>40</height>
+    <width>1466</width>
+    <height>60</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>1366</width>
-    <height>40</height>
+    <width>1466</width>
+    <height>60</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>1366</width>
-    <height>40</height>
+    <width>1466</width>
+    <height>60</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -44,7 +44,7 @@
    <item>
     <widget class="PyDMLabel" name="PyDMLabel_2">
      <property name="enabled">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -75,7 +75,7 @@
    <item>
     <widget class="PyDMLabel" name="PyDMLabel_3">
      <property name="enabled">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -106,7 +106,7 @@
    <item>
     <widget class="PyDMLabel" name="PyDMLabel_4">
      <property name="enabled">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -143,11 +143,11 @@
    <item>
     <widget class="PyDMLabel" name="PyDMLabel_5">
      <property name="enabled">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="minimumSize">
       <size>
-       <width>150</width>
+       <width>250</width>
        <height>0</height>
       </size>
      </property>
@@ -177,7 +177,7 @@
    <item>
     <widget class="PyDMByteIndicator" name="PyDMByteIndicator">
      <property name="enabled">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -215,7 +215,7 @@
    <item>
     <widget class="PyDMPushButton" name="PyDMPushButton">
      <property name="enabled">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -246,7 +246,7 @@
    <item>
     <widget class="PyDMByteIndicator" name="PyDMByteIndicator_5">
      <property name="enabled">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -284,7 +284,7 @@
    <item>
     <widget class="PyDMByteIndicator" name="PyDMByteIndicator_3">
      <property name="enabled">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -322,7 +322,7 @@
    <item>
     <widget class="PyDMLabel" name="PyDMLabel_6">
      <property name="enabled">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -350,7 +350,7 @@
    <item>
     <widget class="PyDMLineEdit" name="PyDMLineEdit">
      <property name="enabled">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -391,7 +391,7 @@
    <item>
     <widget class="PyDMPushButton" name="PyDMPushButton_2">
      <property name="enabled">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -439,7 +439,7 @@ color: rgb(0, 0, 0);</string>
    <item>
     <widget class="PyDMPushButton" name="PyDMPushButton_3">
      <property name="enabled">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="minimumSize">
       <size>

--- a/templates/fastfaults_header.ui
+++ b/templates/fastfaults_header.ui
@@ -6,19 +6,19 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1366</width>
+    <width>1466</width>
     <height>47</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>1366</width>
+    <width>1466</width>
     <height>47</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>1366</width>
+    <width>1466</width>
     <height>47</height>
    </size>
   </property>
@@ -125,7 +125,7 @@
       <widget class="QLabel" name="label_8">
        <property name="minimumSize">
         <size>
-         <width>150</width>
+         <width>250</width>
          <height>0</height>
         </size>
        </property>

--- a/templates/fastfaults_header.ui
+++ b/templates/fastfaults_header.ui
@@ -6,13 +6,13 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1466</width>
+    <width>1470</width>
     <height>47</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>1466</width>
+    <width>1470</width>
     <height>47</height>
    </size>
   </property>
@@ -100,7 +100,7 @@
       <widget class="QLabel" name="label_7">
        <property name="minimumSize">
         <size>
-         <width>350</width>
+         <width>352</width>
          <height>0</height>
         </size>
        </property>
@@ -125,7 +125,7 @@
       <widget class="QLabel" name="label_8">
        <property name="minimumSize">
         <size>
-         <width>250</width>
+         <width>252</width>
          <height>0</height>
         </size>
        </property>

--- a/templates/fastfaults_header.ui
+++ b/templates/fastfaults_header.ui
@@ -6,19 +6,19 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1470</width>
+    <width>1420</width>
     <height>47</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>1470</width>
+    <width>1420</width>
     <height>47</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>1466</width>
+    <width>1420</width>
     <height>47</height>
    </size>
   </property>
@@ -100,13 +100,13 @@
       <widget class="QLabel" name="label_7">
        <property name="minimumSize">
         <size>
-         <width>352</width>
+         <width>302</width>
          <height>0</height>
         </size>
        </property>
        <property name="maximumSize">
         <size>
-         <width>350</width>
+         <width>302</width>
          <height>16777215</height>
         </size>
        </property>


### PR DESCRIPTION
In order to make the text readable without exploding in screen size scrollAreas were added to variable name and to Description along with wordWrap.

WordWrap works perfectly for the description as it has spaces but the variable name is a string without spaces so it has no effect.

This is how it looks now:
![image](https://user-images.githubusercontent.com/8185425/91326911-be6b8d00-e779-11ea-80e5-c64cf825f7ca.png)
