### PR TITLE
FIX: Workaround to at least be able to render something at the Grafana viewer.

### DIFF
--- a/KFE_config.yml
+++ b/KFE_config.yml
@@ -1,7 +1,7 @@
 line_arbiter_prefix: "PMPS:KFE:"
 undulator_kicker_rate_pv: "IOC:BSY0:MP01:BYKIKS_RATE"
 
-dashboard_url: "http://ctl-logsrv01:3000/ctl/grafana/d/PRr2cuGGz/k-pmps-events?viewPanel=2&orgId=1&refresh=10s&kiosk"
+dashboard_url: "http://ctl-logsrv01:3000/ctl/grafana/d/PRr2cuGGz/k-pmps-events?refresh=10s&kiosk"
 
 fastfaults:
   - prefix: "PMPS:KFE:"

--- a/LFE_config.yml
+++ b/LFE_config.yml
@@ -1,7 +1,7 @@
 line_arbiter_prefix: "PMPS:LFE:"
 undulator_kicker_rate_pv: "IOC:BSY0:MP01:BYKIK_RATE"
 
-dashboard_url: "http://ctl-logsrv01:3000/ctl/grafana/d/PQBzCnmMz/l-pmps-events?viewPanel=2&orgId=1&refresh=10s&kiosk"
+dashboard_url: "http://ctl-logsrv01:3000/ctl/grafana/d/PQBzCnmMz/l-pmps-events?refresh=10s&kiosk"
 
 
 fastfaults:


### PR DESCRIPTION
This issue was reported by @slacAWallace and it seems to have showed up after upgrade of Grafana to 7.1.
This is how it renders without this patch:
<img width="1498" alt="Screen Shot 2020-08-26 at 9 40 34 AM" src="https://user-images.githubusercontent.com/8185425/91337101-bca8c600-e787-11ea-8d04-e108a36aa953.png">

And this is how it renders with the patch in place:
<img width="1514" alt="Screen Shot 2020-08-26 at 9 43 22 AM" src="https://user-images.githubusercontent.com/8185425/91337124-c2061080-e787-11ea-8f62-5fafb20217c3.png">

Looking at the changelogs, I noticed that a fixed issue is very similar to what we are seeing: https://github.com/grafana/grafana/issues/26442. While this issue talks about iOS, our embedded webbrowser can also be suffering from the same issue. The fix for this issue was released with 7.1.1...
I put a message for PCDS IT to look into the possibility to upgrade Grafana to a newer version including the bugfixes released.

This PR is just a workaround so users can at least see something I will update the URL to remove the filters on panel and display the whole page. Better somewhat properly rendered than nothing I guess.