### PR TITLE
FIX: Use hardcoded values for the horizontal scale of undulator widgets.

### DIFF
--- a/widgets.py
+++ b/widgets.py
@@ -10,8 +10,8 @@ from pydm.widgets.label import PyDMLabel
 class UndulatorWidget(QtWidgets.QWidget, PyDMPrimitiveWidget):
     CHANNELS = dict(
         seed_number='ca://{prefix}PE:UND:SeedUndulatorNumber_RBV',
-        upper_k='ca://{prefix}PE:UND:HiK_RBV',
-        lower_k='ca://{prefix}PE:UND:LowK_RBV',
+        # upper_k='ca://{prefix}PE:UND:HiK_RBV', # Commented out. Requested to move to hardcoded value
+        # lower_k='ca://{prefix}PE:UND:LowK_RBV', # Commented out. Requested to move to hardcoded value
         active='ca://{prefix}PE:UND:{segment}:Active_RBV',
         curr_k='ca://{prefix}PE:UND:{segment}:KAct_RBV',
         target_k='ca://{prefix}PE:UND:{segment}:KDes_RBV',
@@ -166,8 +166,10 @@ class UndulatorWidget(QtWidgets.QWidget, PyDMPrimitiveWidget):
         painter.setPen(QtGui.QPen(QtCore.Qt.NoPen))
 
         active = self._values['active']
-        upper_k = self._values['upper_k']
-        lower_k = self._values['lower_k']
+        # upper_k = self._values['upper_k']
+        # lower_k = self._values['lower_k']
+        upper_k = 10.0
+        lower_k = 0.0
         curr_k = self._values['curr_k']
         target_k = self._values['target_k']
         severity = self._values['severity']

--- a/widgets.py
+++ b/widgets.py
@@ -168,7 +168,7 @@ class UndulatorWidget(QtWidgets.QWidget, PyDMPrimitiveWidget):
         active = self._values['active']
         # upper_k = self._values['upper_k']
         # lower_k = self._values['lower_k']
-        upper_k = 10.0
+        upper_k = 6.0
         lower_k = 0.0
         curr_k = self._values['curr_k']
         target_k = self._values['target_k']


### PR DESCRIPTION
Looks like the undulators can go over the upper and lower K values! 🤯 
This PR is ready to go pending @slacAWallace confirmation of the values. Initially was 0-10 but maybe it is 0-6... who knows?