### PR TITLE
ENH: Use Time widgets for Override fields

### DIFF
--- a/fast_faults.ui
+++ b/fast_faults.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1488</width>
-    <height>261</height>
+    <width>1528</width>
+    <height>259</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -302,8 +302,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>1468</width>
-        <height>122</height>
+        <width>1508</width>
+        <height>120</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_5">

--- a/templates/fastfaults_entry.ui
+++ b/templates/fastfaults_entry.ui
@@ -434,6 +434,9 @@
      <property name="channel" stdset="0">
       <string>ca://${P}FFO:${FFO}:FF:${FF}:Ovrd:RemainingTime_RBV</string>
      </property>
+     <property name="textFormat" stdset="0">
+      <string>yyyy/MM/dd hh:mm:ss</string>
+     </property>
     </widget>
    </item>
    <item>

--- a/templates/fastfaults_entry.ui
+++ b/templates/fastfaults_entry.ui
@@ -6,19 +6,19 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1510</width>
+    <width>1540</width>
     <height>60</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>1510</width>
+    <width>1540</width>
     <height>60</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>1510</width>
+    <width>1540</width>
     <height>70</height>
    </size>
   </property>
@@ -415,18 +415,21 @@
     <widget class="PyDMDateTimeLabel" name="PyDMDateTimeLabel">
      <property name="minimumSize">
       <size>
-       <width>80</width>
+       <width>100</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>80</width>
+       <width>100</width>
        <height>16777215</height>
       </size>
      </property>
      <property name="toolTip">
       <string/>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -435,7 +438,7 @@
       <string>ca://${P}FFO:${FFO}:FF:${FF}:Ovrd:RemainingTime_RBV</string>
      </property>
      <property name="textFormat" stdset="0">
-      <string>yyyy/MM/dd hh:mm:ss</string>
+      <string>yyyy/MM/dd hh:mm:ss.zzz</string>
      </property>
     </widget>
    </item>

--- a/templates/fastfaults_entry.ui
+++ b/templates/fastfaults_entry.ui
@@ -6,19 +6,19 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1420</width>
+    <width>1510</width>
     <height>60</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>1420</width>
+    <width>1510</width>
     <height>60</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>1420</width>
+    <width>1510</width>
     <height>70</height>
    </size>
   </property>
@@ -44,7 +44,7 @@
    <item>
     <widget class="PyDMLabel" name="PyDMLabel_2">
      <property name="enabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -75,7 +75,7 @@
    <item>
     <widget class="PyDMLabel" name="PyDMLabel_3">
      <property name="enabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -269,7 +269,7 @@
    <item>
     <widget class="PyDMByteIndicator" name="PyDMByteIndicator">
      <property name="enabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -307,7 +307,7 @@
    <item>
     <widget class="PyDMPushButton" name="PyDMPushButton">
      <property name="enabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -338,7 +338,7 @@
    <item>
     <widget class="PyDMByteIndicator" name="PyDMByteIndicator_5">
      <property name="enabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -376,7 +376,7 @@
    <item>
     <widget class="PyDMByteIndicator" name="PyDMByteIndicator_3">
      <property name="enabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -412,10 +412,7 @@
     </widget>
    </item>
    <item>
-    <widget class="PyDMLabel" name="PyDMLabel_6">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
+    <widget class="PyDMDateTimeLabel" name="PyDMDateTimeLabel">
      <property name="minimumSize">
       <size>
        <width>80</width>
@@ -431,39 +428,30 @@
      <property name="toolTip">
       <string/>
      </property>
-     <property name="showUnits" stdset="0">
+     <property name="wordWrap">
       <bool>true</bool>
      </property>
      <property name="channel" stdset="0">
-      <string>ca://${P}FFO:${FFO}:FF:${FF}:Ovrd:ElapsedTime_RBV</string>
+      <string>ca://${P}FFO:${FFO}:FF:${FF}:Ovrd:RemainingTime_RBV</string>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="PyDMLineEdit" name="PyDMLineEdit">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
+    <widget class="PyDMDateTimeEdit" name="PyDMDateTimeEdit">
      <property name="minimumSize">
       <size>
-       <width>100</width>
+       <width>190</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>100</width>
+       <width>190</width>
        <height>16777215</height>
       </size>
      </property>
      <property name="toolTip">
       <string/>
-     </property>
-     <property name="showUnits" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://ca://${P}FFO:${FFO}:FF:${FF}:Ovrd:Duration</string>
      </property>
     </widget>
    </item>
@@ -483,7 +471,7 @@
    <item>
     <widget class="PyDMPushButton" name="PyDMPushButton_2">
      <property name="enabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -531,7 +519,7 @@ color: rgb(0, 0, 0);</string>
    <item>
     <widget class="PyDMPushButton" name="PyDMPushButton_3">
      <property name="enabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -590,9 +578,14 @@ color: rgb(255, 255, 255)</string>
    <header>pydm.widgets.byte</header>
   </customwidget>
   <customwidget>
-   <class>PyDMLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>pydm.widgets.line_edit</header>
+   <class>PyDMDateTimeEdit</class>
+   <extends>QDateTimeEdit</extends>
+   <header>pydm.widgets.datetime</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMDateTimeLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.datetime</header>
   </customwidget>
   <customwidget>
    <class>PyDMPushButton</class>

--- a/templates/fastfaults_header.ui
+++ b/templates/fastfaults_header.ui
@@ -6,19 +6,19 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1510</width>
+    <width>1540</width>
     <height>47</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>1510</width>
+    <width>1540</width>
     <height>47</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>1510</width>
+    <width>1540</width>
     <height>47</height>
    </size>
   </property>
@@ -265,13 +265,13 @@
       <widget class="QLabel" name="label_12">
        <property name="minimumSize">
         <size>
-         <width>80</width>
+         <width>100</width>
          <height>0</height>
         </size>
        </property>
        <property name="maximumSize">
         <size>
-         <width>80</width>
+         <width>100</width>
          <height>16777215</height>
         </size>
        </property>

--- a/templates/fastfaults_header.ui
+++ b/templates/fastfaults_header.ui
@@ -6,19 +6,19 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1420</width>
+    <width>1510</width>
     <height>47</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>1420</width>
+    <width>1510</width>
     <height>47</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>1420</width>
+    <width>1510</width>
     <height>47</height>
    </size>
   </property>
@@ -282,7 +282,7 @@
         </font>
        </property>
        <property name="text">
-        <string>Elapsed Time</string>
+        <string>Estimated Conclusion</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
@@ -329,13 +329,13 @@
           <widget class="QLabel" name="label_10">
            <property name="minimumSize">
             <size>
-             <width>100</width>
+             <width>190</width>
              <height>0</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
-             <width>100</width>
+             <width>190</width>
              <height>16777215</height>
             </size>
            </property>


### PR DESCRIPTION
Please ignore the string fields damaged by gateway issues.
**We will need to test that with a PLC to make sure the fields are being set properly.**
![image](https://user-images.githubusercontent.com/8185425/92977025-b92c6480-f440-11ea-938d-634ef0b4b4eb.png)

Closes #2 