### PR TITLE
Rename requested beam parameters

### DIFF
--- a/pmps.py
+++ b/pmps.py
@@ -27,7 +27,6 @@ def morph_into_vertical(label):
     label.update()
 
 
-
 class PMPS(Display):
     def __init__(self, parent=None, args=None, macros=None):
         if not macros:
@@ -48,6 +47,8 @@ class PMPS(Display):
                 continue
             macros[m] = config.get(m)
 
+        # add CFG macro to display the Line when starting without macros
+        macros['CFG'] = config_name
         super(PMPS, self).__init__(parent=parent, args=args, macros=macros)
 
         self.config = config

--- a/pmps.ui
+++ b/pmps.ui
@@ -329,7 +329,7 @@
              </font>
             </property>
             <property name="text">
-             <string>Requested Beam Parameters</string>
+             <string>Beam Parameter Status</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignCenter</set>

--- a/pmps.ui
+++ b/pmps.ui
@@ -23,6 +23,35 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
+      <widget class="QLabel" name="label">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Line: </string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="line_label">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QLabel {color: rgb(0, 0, 153);}</string>
+       </property>
+       <property name="text">
+        <string>${CFG}</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="enabled">
         <bool>true</bool>

--- a/pmps.ui
+++ b/pmps.ui
@@ -17,7 +17,7 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>PMPS - Diagnostics</string>
+   <string>${CFG} PMPS - Diagnostics</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,1">
    <item>


### PR DESCRIPTION
Trying to close #33 & close #29 - since they are both little ones I put them together. 

Here is what the Line indicator looks like now, but we can move this anywhere where we find it to be more appropriate - maybe in the description of the PyDM window itself? I'm open for suggestions here, also I added some color to it but if we find it distracting I can remove that, same thing with the additional str: `Line: ` I can get rid of it and only have `KFE` or `LFE` displayed.

![line_2](https://user-images.githubusercontent.com/62306310/112088483-238b3380-8b4d-11eb-8a37-4ac25aeecbbb.PNG)
