### PR TITLE
ENH: update all 16bit eV indicators to 32bit

### DIFF
--- a/line_beam_parameters.py
+++ b/line_beam_parameters.py
@@ -16,10 +16,7 @@ class LineBeamParametersControl(Display):
     """
     # object names for all energy range bits checkboxes, set them all
     # to unchecked to start with
-    _bits = {'bit15': False, 'bit14': False, 'bit13': False, 'bit12': False,
-             'bit11': False, 'bit10': False, 'bit9': False, 'bit8': False,
-             'bit7': False, 'bit6': False, 'bit5': False, 'bit4': False,
-             'bit3': False, 'bit2': False, 'bit1': False, 'bit0': False}
+    _bits = {f'bit{num}': False for num in range(32)}
 
     # signal to emit when energy range is changed
     energy_range_signal = QtCore.Signal(int)
@@ -121,6 +118,11 @@ class LineBeamParametersControl(Display):
         """
         if energy_range is None:
             return
+
+        # EPICS is signed but we want the signed 32-bit int
+        if energy_range < 0:
+            energy_range = 2**32 + energy_range
+
         binary_range = list(bin(energy_range).replace("0b", ""))
         binary_list = list(map(int, binary_range))
         self._setting_bits = True

--- a/line_beam_parameters.py
+++ b/line_beam_parameters.py
@@ -16,7 +16,7 @@ class LineBeamParametersControl(Display):
     """
     # object names for all energy range bits checkboxes, set them all
     # to unchecked to start with
-    _bits = {f'bit{num}': False for num in range(32)}
+    _bits = {f'bit{num}': False for num in reversed(range(32))}
 
     # signal to emit when energy range is changed
     energy_range_signal = QtCore.Signal(int)

--- a/line_beam_parameters.py
+++ b/line_beam_parameters.py
@@ -119,7 +119,7 @@ class LineBeamParametersControl(Display):
         if energy_range is None:
             return
 
-        # EPICS is signed but we want the signed 32-bit int
+        # EPICS is signed but we want the unsigned 32-bit int
         if energy_range < 0:
             energy_range = 2**32 + energy_range
 

--- a/line_beam_parameters.ui
+++ b/line_beam_parameters.ui
@@ -17,7 +17,7 @@
    <item row="6" column="1">
     <widget class="PyDMPushButton" name="PyDMPushButton">
      <property name="enabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -87,6 +87,262 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
+      <item>
+       <widget class="QCheckBox" name="bit31">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit30">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit29">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit28">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit27">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit26">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit25">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit24">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit23">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit22">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit21">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit20">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit19">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit18">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit17">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit16">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
       <item>
        <widget class="QCheckBox" name="bit15">
         <property name="styleSheet">
@@ -395,7 +651,7 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
    <item row="5" column="1">
     <widget class="PyDMLineEdit" name="PyDMLineEdit_4">
      <property name="enabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -443,7 +699,7 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
    <item row="0" column="1">
     <widget class="PyDMLineEdit" name="PyDMLineEdit">
      <property name="enabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -473,6 +729,499 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      <property name="spacing">
       <number>0</number>
      </property>
+     <item>
+      <widget class="PyDMLabel" name="label_bit31">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>25000</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[31:31]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit30">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>25000</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[30:30]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit29">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>25000</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[29:29]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit28">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>25000</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[28:28]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit27">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>25000</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[27:27]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit26">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>25000</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[26:26]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit25">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>25000</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[25:25]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit24">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>25000</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[24:24]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit23">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>25000</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[23:23]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit22">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>25000</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[22:22]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit21">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>25000</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[21:21]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit20">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>25000</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[20:20]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit19">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>25000</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[19:19]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit18">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>25000</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[18:18]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit17">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>25000</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[17:17]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit16">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>25000</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[16:16]</string>
+       </property>
+      </widget>
+     </item>
      <item>
       <widget class="PyDMLabel" name="label_bit15">
        <property name="enabled">

--- a/line_beam_parameters.ui
+++ b/line_beam_parameters.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>927</width>
+    <width>1503</width>
     <height>215</height>
    </rect>
   </property>
@@ -716,11 +716,20 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      <property name="toolTip">
       <string/>
      </property>
+     <property name="precision" stdset="0">
+      <number>2</number>
+     </property>
      <property name="showUnits" stdset="0">
-      <bool>true</bool>
+      <bool>false</bool>
+     </property>
+     <property name="precisionFromPV" stdset="0">
+      <bool>false</bool>
      </property>
      <property name="channel" stdset="0">
       <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission</string>
+     </property>
+     <property name="displayFormat" stdset="0">
+      <enum>PyDMLineEdit::Exponential</enum>
      </property>
     </widget>
    </item>

--- a/pmps.ui
+++ b/pmps.ui
@@ -161,7 +161,7 @@
           <item row="2" column="1">
            <widget class="PyDMLabel" name="PyDMLabel">
             <property name="enabled">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="toolTip">
              <string/>
@@ -193,7 +193,7 @@
           <item row="2" column="2">
            <widget class="PyDMLabel" name="PyDMLabel_4">
             <property name="enabled">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="toolTip">
              <string/>
@@ -209,7 +209,7 @@
           <item row="3" column="2">
            <widget class="PyDMLabel" name="PyDMLabel_6">
             <property name="enabled">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="toolTip">
              <string/>
@@ -263,7 +263,7 @@
           <item row="3" column="1">
            <widget class="PyDMLabel" name="PyDMLabel_3">
             <property name="enabled">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="toolTip">
              <string/>
@@ -322,7 +322,7 @@
           <item row="3" column="1" colspan="2">
            <widget class="PyDMByteIndicator" name="PyDMByteIndicator_4">
             <property name="enabled">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="maximumSize">
              <size>
@@ -356,48 +356,17 @@
              <bool>false</bool>
             </property>
             <property name="numBits" stdset="0">
-             <number>16</number>
+             <number>32</number>
             </property>
            </widget>
           </item>
-          <item row="1" column="1" colspan="2">
-           <widget class="PyDMByteIndicator" name="PyDMByteIndicator_2">
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_9">
             <property name="enabled">
              <bool>true</bool>
             </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>16</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string/>
-            </property>
-            <property name="channel" stdset="0">
-             <string>ca://${line_arbiter_prefix}CurrentBP:PhotonEnergyRanges_RBV</string>
-            </property>
-            <property name="onColor" stdset="0">
-             <color>
-              <red>10</red>
-              <green>90</green>
-              <blue>179</blue>
-             </color>
-            </property>
-            <property name="orientation" stdset="0">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="showLabels" stdset="0">
-             <bool>false</bool>
-            </property>
-            <property name="bigEndian" stdset="0">
-             <bool>true</bool>
-            </property>
-            <property name="circles" stdset="0">
-             <bool>false</bool>
-            </property>
-            <property name="numBits" stdset="0">
-             <number>16</number>
+            <property name="text">
+             <string>Requested</string>
             </property>
            </widget>
           </item>
@@ -406,6 +375,406 @@
             <property name="spacing">
              <number>0</number>
             </property>
+            <item>
+             <widget class="PyDMLabel" name="PyDMLabel_39">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="font">
+               <font>
+                <family>Arial</family>
+                <pointsize>8</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>25000</string>
+              </property>
+              <property name="precisionFromPV" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="channel" stdset="0">
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[31:31]</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="PyDMLabel" name="PyDMLabel_38">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="font">
+               <font>
+                <family>Arial</family>
+                <pointsize>8</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>25000</string>
+              </property>
+              <property name="precisionFromPV" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="channel" stdset="0">
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[30:30]</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="PyDMLabel" name="PyDMLabel_37">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="font">
+               <font>
+                <family>Arial</family>
+                <pointsize>8</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>25000</string>
+              </property>
+              <property name="precisionFromPV" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="channel" stdset="0">
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[29:29]</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="PyDMLabel" name="PyDMLabel_36">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="font">
+               <font>
+                <family>Arial</family>
+                <pointsize>8</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>25000</string>
+              </property>
+              <property name="precisionFromPV" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="channel" stdset="0">
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[28:28]</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="PyDMLabel" name="PyDMLabel_35">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="font">
+               <font>
+                <family>Arial</family>
+                <pointsize>8</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>25000</string>
+              </property>
+              <property name="precisionFromPV" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="channel" stdset="0">
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[27:27]</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="PyDMLabel" name="PyDMLabel_34">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="font">
+               <font>
+                <family>Arial</family>
+                <pointsize>8</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>25000</string>
+              </property>
+              <property name="precisionFromPV" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="channel" stdset="0">
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[26:26]</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="PyDMLabel" name="PyDMLabel_33">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="font">
+               <font>
+                <family>Arial</family>
+                <pointsize>8</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>25000</string>
+              </property>
+              <property name="precisionFromPV" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="channel" stdset="0">
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[25:25]</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="PyDMLabel" name="PyDMLabel_32">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="font">
+               <font>
+                <family>Arial</family>
+                <pointsize>8</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>25000</string>
+              </property>
+              <property name="precisionFromPV" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="channel" stdset="0">
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[24:24]</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="PyDMLabel" name="PyDMLabel_31">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="font">
+               <font>
+                <family>Arial</family>
+                <pointsize>8</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>25000</string>
+              </property>
+              <property name="precisionFromPV" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="channel" stdset="0">
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[23:23]</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="PyDMLabel" name="PyDMLabel_30">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="font">
+               <font>
+                <family>Arial</family>
+                <pointsize>8</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>25000</string>
+              </property>
+              <property name="precisionFromPV" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="channel" stdset="0">
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[22:22]</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="PyDMLabel" name="PyDMLabel_29">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="font">
+               <font>
+                <family>Arial</family>
+                <pointsize>8</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>25000</string>
+              </property>
+              <property name="precisionFromPV" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="channel" stdset="0">
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[21:21]</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="PyDMLabel" name="PyDMLabel_28">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="font">
+               <font>
+                <family>Arial</family>
+                <pointsize>8</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>25000</string>
+              </property>
+              <property name="precisionFromPV" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="channel" stdset="0">
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[20:20]</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="PyDMLabel" name="PyDMLabel_27">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="font">
+               <font>
+                <family>Arial</family>
+                <pointsize>8</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>25000</string>
+              </property>
+              <property name="precisionFromPV" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="channel" stdset="0">
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[19:19]</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="PyDMLabel" name="PyDMLabel_26">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="font">
+               <font>
+                <family>Arial</family>
+                <pointsize>8</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>25000</string>
+              </property>
+              <property name="precisionFromPV" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="channel" stdset="0">
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[18:18]</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="PyDMLabel" name="PyDMLabel_25">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="font">
+               <font>
+                <family>Arial</family>
+                <pointsize>8</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>25000</string>
+              </property>
+              <property name="precisionFromPV" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="channel" stdset="0">
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[17:17]</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="PyDMLabel" name="PyDMLabel_24">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="font">
+               <font>
+                <family>Arial</family>
+                <pointsize>8</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>25000</string>
+              </property>
+              <property name="precisionFromPV" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="channel" stdset="0">
+               <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[16:16]</string>
+              </property>
+             </widget>
+            </item>
             <item>
              <widget class="PyDMLabel" name="PyDMLabel_7">
               <property name="enabled">
@@ -808,36 +1177,10 @@
             </item>
            </layout>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_10">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="text">
-             <string>Current</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_8">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="font">
-             <font>
-              <weight>75</weight>
-              <bold>true</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>eV</string>
-            </property>
-           </widget>
-          </item>
           <item row="2" column="1" colspan="2">
            <widget class="PyDMByteIndicator" name="PyDMByteIndicator_3">
             <property name="enabled">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="maximumSize">
              <size>
@@ -871,7 +1214,74 @@
              <bool>false</bool>
             </property>
             <property name="numBits" stdset="0">
-             <number>16</number>
+             <number>32</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_10">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="text">
+             <string>Current</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_8">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>eV</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1" colspan="2">
+           <widget class="PyDMByteIndicator" name="PyDMByteIndicator_2">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>16</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="channel" stdset="0">
+             <string>ca://${line_arbiter_prefix}CurrentBP:PhotonEnergyRanges_RBV</string>
+            </property>
+            <property name="onColor" stdset="0">
+             <color>
+              <red>10</red>
+              <green>90</green>
+              <blue>179</blue>
+             </color>
+            </property>
+            <property name="orientation" stdset="0">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="showLabels" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="bigEndian" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="circles" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="numBits" stdset="0">
+             <number>32</number>
             </property>
            </widget>
           </item>
@@ -882,16 +1292,6 @@
             </property>
             <property name="text">
              <string>Residual</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_9">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="text">
-             <string>Requested</string>
             </property>
            </widget>
           </item>

--- a/pmps.ui
+++ b/pmps.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1486</width>
+    <width>1767</width>
     <height>742</height>
    </rect>
   </property>
@@ -214,11 +214,20 @@
             <property name="toolTip">
              <string/>
             </property>
+            <property name="precision" stdset="0">
+             <number>0</number>
+            </property>
             <property name="showUnits" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="precisionFromPV" stdset="0">
              <bool>true</bool>
             </property>
             <property name="channel" stdset="0">
              <string>ca://${line_arbiter_prefix}RequestedBP:Transmission_RBV</string>
+            </property>
+            <property name="displayFormat" stdset="0">
+             <enum>PyDMLabel::Exponential</enum>
             </property>
            </widget>
           </item>
@@ -268,11 +277,20 @@
             <property name="toolTip">
              <string/>
             </property>
+            <property name="precision" stdset="0">
+             <number>0</number>
+            </property>
             <property name="showUnits" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="precisionFromPV" stdset="0">
              <bool>true</bool>
             </property>
             <property name="channel" stdset="0">
              <string>ca://${line_arbiter_prefix}CurrentBP:Transmission_RBV</string>
+            </property>
+            <property name="displayFormat" stdset="0">
+             <enum>PyDMLabel::Exponential</enum>
             </property>
            </widget>
           </item>

--- a/templates/preemptive_requests_entry.ui
+++ b/templates/preemptive_requests_entry.ui
@@ -141,6 +141,9 @@
      <property name="channel" stdset="0">
       <string>ca://${P}${ARBITER}:AP:Entry:${POOL}:Transmission_RBV</string>
      </property>
+     <property name="displayFormat" stdset="0">
+      <enum>PyDMLabel::Exponential</enum>
+     </property>
     </widget>
    </item>
    <item>

--- a/templates/preemptive_requests_entry.ui
+++ b/templates/preemptive_requests_entry.ui
@@ -6,19 +6,19 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>856</width>
+    <width>1056</width>
     <height>40</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>856</width>
+    <width>1056</width>
     <height>40</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>856</width>
+    <width>1056</width>
     <height>40</height>
    </size>
   </property>
@@ -156,13 +156,13 @@
      </property>
      <property name="minimumSize">
       <size>
-       <width>200</width>
+       <width>400</width>
        <height>16</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>200</width>
+       <width>400</width>
        <height>16</height>
       </size>
      </property>
@@ -192,7 +192,7 @@
       <bool>false</bool>
      </property>
      <property name="numBits" stdset="0">
-      <number>16</number>
+      <number>32</number>
      </property>
     </widget>
    </item>

--- a/templates/preemptive_requests_header.ui
+++ b/templates/preemptive_requests_header.ui
@@ -6,19 +6,19 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>856</width>
+    <width>1056</width>
     <height>47</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>856</width>
+    <width>1056</width>
     <height>47</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>856</width>
+    <width>1056</width>
     <height>47</height>
    </size>
   </property>
@@ -89,13 +89,13 @@
         <widget class="QLabel" name="label_4">
          <property name="minimumSize">
           <size>
-           <width>400</width>
+           <width>600</width>
            <height>0</height>
           </size>
          </property>
          <property name="maximumSize">
           <size>
-           <width>400</width>
+           <width>600</width>
            <height>16777215</height>
           </size>
          </property>
@@ -188,13 +188,13 @@
           <widget class="QLabel" name="label_11">
            <property name="minimumSize">
             <size>
-             <width>200</width>
+             <width>400</width>
              <height>0</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
-             <width>200</width>
+             <width>400</width>
              <height>16777215</height>
             </size>
            </property>
@@ -208,7 +208,7 @@
             <string>Photon Energy Ranges</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            <set>Qt::AlignCenter</set>
            </property>
           </widget>
          </item>
@@ -297,13 +297,13 @@
     <widget class="Line" name="line">
      <property name="minimumSize">
       <size>
-       <width>856</width>
+       <width>1056</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>856</width>
+       <width>1056</width>
        <height>16777215</height>
       </size>
      </property>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10647860/116340138-821e7f80-a793-11eb-808a-23d4d24217bb.png)

Three main changes:
- At the top, the three bitmasks needed to be extended
- In the preemptive request tab, each line's bitmask needed to be extended. This tab uses fixed widths so those were adjusted as well.
- In the line beam parameters control, the number of available bits had to be doubled.

Main confounding factor: EPICS Long types are 32 bit signed integers. So something like "all ones" or `FFFFFFFF` comes through as `-1`, which shows up as empty on the pydm bit indicator.

This PR uses a quick hack to edit the pydm behavior, though this should go to pydm as a feature instead, and it also edits the processing used in the line beam parameter controls.