### PR TITLE
ENH: Datetime continuation

### DIFF
--- a/TST_config.yml
+++ b/TST_config.yml
@@ -1,0 +1,18 @@
+line_arbiter_prefix: "PMPS:LFE:"
+undulator_kicker_rate_pv: "IOC:BSY0:MP01:BYKIK_RATE"
+
+dashboard_url: "http://ctl-logsrv01:3000/ctl/grafana/d/PQBzCnmMz/l-pmps-events?refresh=10s&kiosk"
+
+
+fastfaults:
+  - prefix: "PLC:TST:MOT:"
+    ffo_start: 1
+    ffo_end: 1
+    ff_start: 1
+    ff_end: 50
+
+preemptive_requests:
+  - prefix: "PMPS:LFE:"
+    arbiter_instance: "Arbiter:01"
+    assertion_pool_start: 1
+    assertion_pool_end: 20

--- a/fast_faults.py
+++ b/fast_faults.py
@@ -6,6 +6,7 @@ from string import Template
 from pydm import Display
 from pydm.widgets import PyDMEmbeddedDisplay
 from pydm.widgets.channel import PyDMChannel
+from pydm.widgets.datetime import PyDMDateTimeEdit, PyDMDateTimeLabel
 from qtpy import QtCore, QtWidgets
 
 
@@ -68,6 +69,9 @@ class FastFaults(Display):
     def setup_ui(self):
         self.ui.btn_apply_filters.clicked.connect(self.update_filters)
         self.setup_fastfaults()
+        self.timer = QtCore.QTimer()
+        self.timer.timeout.connect(self.update_min_times)
+        self.timer.start(10000)
 
     def setup_fastfaults(self):
         ffs = self.config.get('fastfaults')
@@ -134,3 +138,10 @@ class FastFaults(Display):
                 opt['condition'] = cb.currentIndex()
                 filters.append(opt)
         self.filters_changed.emit(filters)
+
+    def update_min_times(self):
+        current_time = QtCore.QDateTime.currentSecsSinceEpoch()
+        latest_minute = current_time // 60 * 60
+        min_time = QtCore.QDateTime.fromSecsSinceEpoch(latest_minute)
+        for widget in self.findChildren(PyDMDateTimeEdit, 'ExpirationSelect'):
+            widget.setMinimumDateTime(min_time)

--- a/fast_faults.py
+++ b/fast_faults.py
@@ -71,6 +71,7 @@ class FastFaults(Display):
         self.setup_fastfaults()
         self.timer = QtCore.QTimer()
         self.timer.timeout.connect(self.update_min_times)
+        self.timer.singleShot(1000, self.update_min_times)
         self.timer.start(10000)
 
     def setup_fastfaults(self):

--- a/fast_faults.ui
+++ b/fast_faults.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1488</width>
+    <width>1662</width>
     <height>261</height>
    </rect>
   </property>
@@ -38,9 +38,15 @@
    </item>
    <item>
     <widget class="QFrame" name="ff_frame_filters">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
      <property name="maximumSize">
       <size>
-       <width>16777215</width>
+       <width>1644</width>
        <height>70</height>
       </size>
      </property>
@@ -302,9 +308,15 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>1468</width>
-        <height>122</height>
+        <width>1642</width>
+        <height>123</height>
        </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_5">
        <property name="spacing">

--- a/pmps.py
+++ b/pmps.py
@@ -4,6 +4,7 @@ from os import path
 import yaml
 from pydm import Display
 from pydm.widgets import PyDMByteIndicator, PyDMLabel
+from pydm.widgets.datetime import PyDMDateTimeEdit, TimeBase
 from qtpy import QtCore, QtGui, QtWidgets
 
 
@@ -159,3 +160,25 @@ def update_indicators(self):
 
 
 PyDMByteIndicator.update_indicators = update_indicators
+
+
+# Hack for broken datetime widget
+def send_value(self):
+    val = self.dateTime()
+    now = QtCore.QDateTime.currentDateTime()
+    if self._block_past_date and val < now:
+        #logger.error('Selected date cannot be lower than current date.')
+        print('Selected date cannot be lower than current date.')
+        return
+
+    if self.relative:
+        new_value = now.msecsTo(val)
+    else:
+        new_value = val.toMSecsSinceEpoch()
+
+    if self.timeBase == TimeBase.Seconds:
+        new_value /= 1000.0
+    self.send_value_signal.emit(new_value)
+
+
+PyDMDateTimeEdit.send_value = send_value

--- a/templates/fastfaults_entry.ui
+++ b/templates/fastfaults_entry.ui
@@ -137,7 +137,7 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>275</width>
+        <width>274</width>
         <height>58</height>
        </rect>
       </property>
@@ -220,7 +220,7 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>275</width>
+        <width>274</width>
         <height>58</height>
        </rect>
       </property>
@@ -418,35 +418,70 @@
     </widget>
    </item>
    <item>
-    <widget class="PyDMDateTimeLabel" name="ExpirationShow">
-     <property name="minimumSize">
-      <size>
-       <width>185</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>185</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${P}FFO:${FFO}:FF:${FF}:Ovrd:Duration_RBV</string>
-     </property>
-     <property name="timeBase" stdset="0">
-      <enum>PyDMDateTimeLabel::Seconds</enum>
-     </property>
-     <property name="relative" stdset="0">
-      <bool>false</bool>
-     </property>
-    </widget>
+    <layout class="QVBoxLayout" name="verticalLayout_3">
+     <item>
+      <widget class="PyDMDateTimeLabel" name="OverrideStartDate">
+       <property name="minimumSize">
+        <size>
+         <width>185</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>185</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${P}FFO:${FFO}:FF:${FF}:Ovrd:StartDT_RBV</string>
+       </property>
+       <property name="timeBase" stdset="0">
+        <enum>PyDMDateTimeLabel::Seconds</enum>
+       </property>
+       <property name="relative" stdset="0">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMDateTimeLabel" name="ExpirationShow">
+       <property name="minimumSize">
+        <size>
+         <width>185</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>185</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${P}FFO:${FFO}:FF:${FF}:Ovrd:Expiration_RBV</string>
+       </property>
+       <property name="timeBase" stdset="0">
+        <enum>PyDMDateTimeLabel::Seconds</enum>
+       </property>
+       <property name="relative" stdset="0">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="PyDMDateTimeEdit" name="ExpirationSelect">
@@ -469,7 +504,7 @@
       <bool>false</bool>
      </property>
      <property name="channel" stdset="0">
-      <string>ca://${P}FFO:${FFO}:FF:${FF}:Ovrd:Duration</string>
+      <string>ca://${P}FFO:${FFO}:FF:${FF}:Ovrd:Expiration</string>
      </property>
      <property name="timeBase" stdset="0">
       <enum>PyDMDateTimeEdit::Seconds</enum>

--- a/templates/fastfaults_entry.ui
+++ b/templates/fastfaults_entry.ui
@@ -48,7 +48,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="PyDMLabel" name="PyDMLabel_2">
+    <widget class="PyDMLabel" name="DeviceName">
      <property name="enabled">
       <bool>true</bool>
      </property>
@@ -79,7 +79,7 @@
     </widget>
    </item>
    <item>
-    <widget class="PyDMLabel" name="PyDMLabel_3">
+    <widget class="PyDMLabel" name="TypeCode">
      <property name="enabled">
       <bool>true</bool>
      </property>
@@ -158,7 +158,7 @@
         <number>0</number>
        </property>
        <item>
-        <widget class="PyDMLabel" name="PyDMLabel_4">
+        <widget class="PyDMLabel" name="Path">
          <property name="enabled">
           <bool>false</bool>
          </property>
@@ -241,7 +241,7 @@
         <number>0</number>
        </property>
        <item>
-        <widget class="PyDMLabel" name="PyDMLabel_5">
+        <widget class="PyDMLabel" name="Desc">
          <property name="enabled">
           <bool>false</bool>
          </property>
@@ -273,7 +273,7 @@
     </widget>
    </item>
    <item>
-    <widget class="PyDMByteIndicator" name="PyDMByteIndicator">
+    <widget class="PyDMByteIndicator" name="FFOk">
      <property name="enabled">
       <bool>true</bool>
      </property>
@@ -342,7 +342,7 @@
     </widget>
    </item>
    <item>
-    <widget class="PyDMByteIndicator" name="PyDMByteIndicator_5">
+    <widget class="PyDMByteIndicator" name="FFBeamOk">
      <property name="enabled">
       <bool>true</bool>
      </property>
@@ -380,7 +380,7 @@
     </widget>
    </item>
    <item>
-    <widget class="PyDMByteIndicator" name="PyDMByteIndicator_3">
+    <widget class="PyDMByteIndicator" name="BypassIndicator">
      <property name="enabled">
       <bool>true</bool>
      </property>
@@ -418,7 +418,7 @@
     </widget>
    </item>
    <item>
-    <widget class="PyDMDateTimeLabel" name="PyDMDateTimeLabel">
+    <widget class="PyDMDateTimeLabel" name="ExpirationShow">
      <property name="minimumSize">
       <size>
        <width>185</width>
@@ -438,12 +438,18 @@
       <set>Qt::AlignCenter</set>
      </property>
      <property name="channel" stdset="0">
-      <string>ca://${P}FFO:${FFO}:FF:${FF}:Ovrd:RemainingTime_RBV</string>
+      <string>ca://${P}FFO:${FFO}:FF:${FF}:Ovrd:Duration_RBV</string>
+     </property>
+     <property name="timeBase" stdset="0">
+      <enum>PyDMDateTimeLabel::Seconds</enum>
+     </property>
+     <property name="relative" stdset="0">
+      <bool>false</bool>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="PyDMDateTimeEdit" name="PyDMDateTimeEdit">
+    <widget class="PyDMDateTimeEdit" name="ExpirationSelect">
      <property name="minimumSize">
       <size>
        <width>185</width>
@@ -465,6 +471,15 @@
      <property name="channel" stdset="0">
       <string>ca://${P}FFO:${FFO}:FF:${FF}:Ovrd:Duration</string>
      </property>
+     <property name="timeBase" stdset="0">
+      <enum>PyDMDateTimeEdit::Seconds</enum>
+     </property>
+     <property name="relative" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="blockPastDate" stdset="0">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item>
@@ -484,7 +499,7 @@
     </spacer>
    </item>
    <item>
-    <widget class="PyDMPushButton" name="PyDMPushButton_2">
+    <widget class="PyDMPushButton" name="BypassActivate">
      <property name="enabled">
       <bool>true</bool>
      </property>
@@ -535,7 +550,7 @@ color: rgb(0, 0, 0);</string>
     </spacer>
    </item>
    <item>
-    <widget class="PyDMPushButton" name="PyDMPushButton_3">
+    <widget class="PyDMPushButton" name="BypassDeactivate">
      <property name="enabled">
       <bool>true</bool>
      </property>

--- a/templates/fastfaults_entry.ui
+++ b/templates/fastfaults_entry.ui
@@ -6,19 +6,25 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1556</width>
+    <width>1644</width>
     <height>60</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
   <property name="minimumSize">
    <size>
-    <width>1556</width>
+    <width>0</width>
     <height>60</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>1556</width>
+    <width>1644</width>
     <height>70</height>
    </size>
   </property>
@@ -107,13 +113,13 @@
     <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>302</width>
+       <width>0</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>302</width>
+       <width>277</width>
        <height>16777215</height>
       </size>
      </property>
@@ -131,7 +137,7 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>300</width>
+        <width>275</width>
         <height>58</height>
        </rect>
       </property>
@@ -157,7 +163,7 @@
           <bool>false</bool>
          </property>
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -190,13 +196,13 @@
     <widget class="QScrollArea" name="scrollArea_2">
      <property name="minimumSize">
       <size>
-       <width>252</width>
+       <width>0</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>252</width>
+       <width>277</width>
        <height>16777215</height>
       </size>
      </property>
@@ -214,7 +220,7 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>250</width>
+        <width>275</width>
         <height>58</height>
        </rect>
       </property>
@@ -428,6 +434,9 @@
      <property name="toolTip">
       <string/>
      </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
      <property name="channel" stdset="0">
       <string>ca://${P}FFO:${FFO}:FF:${FF}:Ovrd:RemainingTime_RBV</string>
      </property>
@@ -450,6 +459,9 @@
      <property name="toolTip">
       <string/>
      </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>false</bool>
+     </property>
      <property name="channel" stdset="0">
       <string>ca://${P}FFO:${FFO}:FF:${FF}:Ovrd:Duration</string>
      </property>
@@ -460,9 +472,12 @@
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>40</width>
+       <width>20</width>
        <height>20</height>
       </size>
      </property>
@@ -508,9 +523,12 @@ color: rgb(0, 0, 0);</string>
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>40</width>
+       <width>20</width>
        <height>20</height>
       </size>
      </property>
@@ -556,9 +574,12 @@ color: rgb(255, 255, 255)</string>
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>40</width>
+       <width>20</width>
        <height>20</height>
       </size>
      </property>

--- a/templates/fastfaults_header.ui
+++ b/templates/fastfaults_header.ui
@@ -306,7 +306,7 @@
         </font>
        </property>
        <property name="text">
-        <string>Expiration Time</string>
+        <string>Bypass Start/End</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>

--- a/templates/fastfaults_header.ui
+++ b/templates/fastfaults_header.ui
@@ -6,19 +6,25 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1556</width>
+    <width>1659</width>
     <height>47</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
   <property name="minimumSize">
    <size>
-    <width>1556</width>
+    <width>0</width>
     <height>47</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>1556</width>
+    <width>1659</width>
     <height>47</height>
    </size>
   </property>
@@ -98,15 +104,21 @@
      </item>
      <item>
       <widget class="QLabel" name="label_7">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="minimumSize">
         <size>
-         <width>302</width>
+         <width>0</width>
          <height>0</height>
         </size>
        </property>
        <property name="maximumSize">
         <size>
-         <width>302</width>
+         <width>277</width>
          <height>16777215</height>
         </size>
        </property>
@@ -119,19 +131,28 @@
        <property name="text">
         <string>PLC Var. Name</string>
        </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
       </widget>
      </item>
      <item>
       <widget class="QLabel" name="label_8">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="minimumSize">
         <size>
-         <width>252</width>
+         <width>0</width>
          <height>0</height>
         </size>
        </property>
        <property name="maximumSize">
         <size>
-         <width>150</width>
+         <width>277</width>
          <height>16777215</height>
         </size>
        </property>
@@ -143,6 +164,9 @@
        </property>
        <property name="text">
         <string>Description</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
        </property>
       </widget>
      </item>
@@ -282,7 +306,7 @@
         </font>
        </property>
        <property name="text">
-        <string>Estimated Conclusion</string>
+        <string>Expiration Time</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
@@ -299,6 +323,18 @@
        </property>
        <item>
         <widget class="QLabel" name="label_4">
+         <property name="minimumSize">
+          <size>
+           <width>385</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>385</width>
+           <height>16777215</height>
+          </size>
+         </property>
          <property name="font">
           <font>
            <weight>75</weight>
@@ -346,7 +382,7 @@
             </font>
            </property>
            <property name="text">
-            <string>Duration</string>
+            <string>Expiration Time</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignCenter</set>
@@ -357,13 +393,13 @@
           <widget class="QLabel" name="label_11">
            <property name="minimumSize">
             <size>
-             <width>160</width>
+             <width>200</width>
              <height>0</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
-             <width>160</width>
+             <width>200</width>
              <height>16777215</height>
             </size>
            </property>
@@ -384,6 +420,22 @@
         </layout>
        </item>
       </layout>
+     </item>
+     <item>
+      <spacer name="scrollbarspacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>15</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
Continuation of #24

- [x] Merge Hugo's changes from #24 into master
- [x] Adjustments for small screen visibility
- [x] Switch to correct PVs/settings for absolute, not relative sets, once defined

Current look at 1366x768, which is my laptop resolution. Note how the var name and desc fields collapse to make room for the larger datetime widgets:
![image](https://user-images.githubusercontent.com/10647860/118726267-ee662f00-b7e5-11eb-820b-99f83a0f66a1.png)