### PR TITLE
ENH: Many fixes and features

### DIFF
--- a/KFE_config.yml
+++ b/KFE_config.yml
@@ -101,11 +101,31 @@ preemptive_requests:
     assertion_pool_end: 20
 
   - prefix: "PLC:RIX:OPTICS:"
-    arbiter_instance: "ARB"
+    arbiter_instance: "ARB:01"
+    assertion_pool_start: 1
+    assertion_pool_end: 20
+
+  - prefix: "PLC:RIX:OPTICS:"
+    arbiter_instance: "ARB:02"
     assertion_pool_start: 1
     assertion_pool_end: 20
 
   - prefix: "PLC:RIX:MOTION:"
-    arbiter_instance: "ARB"
+    arbiter_instance: "ARB:01"
     assertion_pool_start: 1
     assertion_pool_end: 50
+
+  - prefix: "PLC:RIX:MOTION:"
+    arbiter_instance: "ARB:02"
+    assertion_pool_start: 1
+    assertion_pool_end: 20
+
+  - prefix: "PLC:KFE:RIX:VAC:"
+    arbiter_instance: "ARB:01"
+    assertion_pool_start: 1
+    assertion_pool_end: 20
+
+  - prefix: "PLC:KFE:RIX:VAC:"
+    arbiter_instance: "ARB:02"
+    assertion_pool_start: 1
+    assertion_pool_end: 20

--- a/KFE_config.yml
+++ b/KFE_config.yml
@@ -20,7 +20,7 @@ fastfaults:
     ffo_start: 1
     ffo_end: 4
     ff_start: 1
-    ff_end: 10
+    ff_end: 20
 
   - prefix: "PLC:TMO:VAC:"
     ffo_start: 1

--- a/data_bounds.py
+++ b/data_bounds.py
@@ -1,0 +1,26 @@
+# List of valid rate selections from high to low in Hz
+VALID_RATES = [120, 10, 1, 0]
+
+def get_valid_rate(rate):
+    """
+    Return the real rate that we'll request from ACR.
+
+    Not all rate requests are valid, there is a strict
+    set that we are allowed to request. Requesting an
+    inbetween value is the same as requesting the next
+    lowest available value.
+
+    Parameters
+    ----------
+    rate : int
+        The rate in Hz that we want to request.
+
+    Returns
+    -------
+    valid_rate : int
+        The rate in Hz that is actually requested.
+    """
+    for valid_rate in VALID_RATES:
+        if rate >= valid_rate:
+            return valid_rate
+    return 0

--- a/data_bounds.py
+++ b/data_bounds.py
@@ -1,5 +1,5 @@
 # List of valid rate selections from high to low in Hz
-VALID_RATES = [120, 10, 1, 0]
+VALID_RATES = (120, 10, 1, 0)
 
 def get_valid_rate(rate):
     """

--- a/fast_faults.py
+++ b/fast_faults.py
@@ -122,7 +122,11 @@ class FastFaults(Display):
 
     def update_filters(self):
         default_options = [
-            {'name': 'inuse', 'channel': 'ca://${P}FFO:${FFO}:FF:${FF}:Info:InUse_RBV', 'condition': 1}
+            {
+                'name': 'inuse',
+                'channel': 'ca://${P}FFO:${FFO}:FF:${FF}:Info:InUse_RBV',
+                'condition': '"TRUE"',
+            }
         ]
         options = [
             {'name': 'ok', 'channel': 'ca://${P}FFO:${FFO}:FF:${FF}:OK_RBV'},
@@ -136,7 +140,7 @@ class FastFaults(Display):
             gb = self.findChild(QtWidgets.QGroupBox, f"ff_filter_gb_{opt['name']}")
             cb = self.findChild(QtWidgets.QComboBox, f"ff_filter_cb_{opt['name']}")
             if gb.isChecked():
-                opt['condition'] = cb.currentIndex()
+                opt['condition'] = '"' + str(cb.currentText()).upper() + '"'
                 filters.append(opt)
         self.filters_changed.emit(filters)
 

--- a/fast_faults.py
+++ b/fast_faults.py
@@ -168,9 +168,9 @@ class FastFaults(Display):
     def update_time_delta(self, arbiter_time):
         client_time = QtCore.QDateTime.currentSecsSinceEpoch()
         diff = arbiter_time - client_time
-        text = f'({diff:+d})'
+        text = f'({diff:+d}s)'
         self.ui.time_delta_label.setText(text)
         if abs(diff) >= 5:
             self.ui.time_delta_label.setStyleSheet("QLabel { color : red; }")
         elif abs(diff) < 2:
-            self.ui.time_delta.label.setStyleSheet("QLabel { color : black; }")
+            self.ui.time_delta_label.setStyleSheet("QLabel { color : black; }")

--- a/fast_faults.ui
+++ b/fast_faults.ui
@@ -341,21 +341,14 @@
           </spacer>
          </item>
          <item>
-          <layout class="QVBoxLayout" name="verticalLayout_3">
-           <property name="leftMargin">
+          <layout class="QGridLayout" name="gridLayout">
+           <property name="topMargin">
             <number>0</number>
            </property>
-           <item>
-            <widget class="QLabel" name="label">
-             <property name="text">
-              <string>Local Arbiter Time:</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignCenter</set>
-             </property>
-            </widget>
-           </item>
-           <item>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <item row="1" column="0">
             <widget class="PyDMDateTimeLabel" name="PyDMDateTimeLabel">
              <property name="toolTip">
               <string/>
@@ -366,11 +359,34 @@
              <property name="channel" stdset="0">
               <string>ca://${line_arbiter_prefix}SystemDT_RBV</string>
              </property>
+             <property name="textFormat" stdset="0">
+              <string>yyyy/MM/dd hh:mm:ss.zzz</string>
+             </property>
              <property name="timeBase" stdset="0">
               <enum>PyDMDateTimeLabel::Seconds</enum>
              </property>
              <property name="relative" stdset="0">
               <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label">
+             <property name="text">
+              <string>Local Arbiter Time:</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLabel" name="time_delta_label">
+             <property name="text">
+              <string/>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>

--- a/fast_faults.ui
+++ b/fast_faults.ui
@@ -341,36 +341,11 @@
           </spacer>
          </item>
          <item>
-          <layout class="QGridLayout" name="gridLayout">
-           <property name="topMargin">
+          <layout class="QVBoxLayout" name="verticalLayout_3">
+           <property name="leftMargin">
             <number>0</number>
            </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <item row="1" column="0">
-            <widget class="PyDMDateTimeLabel" name="PyDMDateTimeLabel">
-             <property name="toolTip">
-              <string/>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignCenter</set>
-             </property>
-             <property name="channel" stdset="0">
-              <string>ca://${line_arbiter_prefix}SystemDT_RBV</string>
-             </property>
-             <property name="textFormat" stdset="0">
-              <string>yyyy/MM/dd hh:mm:ss.zzz</string>
-             </property>
-             <property name="timeBase" stdset="0">
-              <enum>PyDMDateTimeLabel::Seconds</enum>
-             </property>
-             <property name="relative" stdset="0">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="0">
+           <item>
             <widget class="QLabel" name="label">
              <property name="text">
               <string>Local Arbiter Time:</string>
@@ -380,15 +355,41 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="1">
-            <widget class="QLabel" name="time_delta_label">
-             <property name="text">
-              <string/>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignCenter</set>
-             </property>
-            </widget>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_6">
+             <item>
+              <widget class="PyDMDateTimeLabel" name="PyDMDateTimeLabel">
+               <property name="toolTip">
+                <string/>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+               <property name="channel" stdset="0">
+                <string>ca://${line_arbiter_prefix}SystemDT_RBV</string>
+               </property>
+               <property name="textFormat" stdset="0">
+                <string>yyyy/MM/dd hh:mm:ss.zzz</string>
+               </property>
+               <property name="timeBase" stdset="0">
+                <enum>PyDMDateTimeLabel::Seconds</enum>
+               </property>
+               <property name="relative" stdset="0">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="time_delta_label">
+               <property name="text">
+                <string/>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
           </layout>
          </item>

--- a/line_beam_parameters.py
+++ b/line_beam_parameters.py
@@ -7,6 +7,7 @@ from pydm.widgets import PyDMLabel
 from pydm.widgets.channel import PyDMChannel
 from qtpy import QtCore, QtWidgets
 
+from data_bounds import VALID_RATES, get_valid_rate
 from fast_faults import clear_channel
 from pmps import morph_into_vertical
 
@@ -33,9 +34,6 @@ class LineBeamParametersControl(Display):
 
     # Signal to set a new rate from the combobox or from zero rate button
     update_rate_signal = QtCore.Signal(int)
-
-    # List of valid rate selections from high to low in Hz
-    valid_rates = [120, 10, 1, 0]
 
 
     def __init__(self, parent=None, args=None, macros=None):
@@ -212,7 +210,7 @@ class LineBeamParametersControl(Display):
         """
         Fill the combobox for rate selection and make it work.
         """
-        for rate in self.valid_rates:
+        for rate in VALID_RATES:
             self.ui.rateComboBox.addItem(f'{rate} Hz')
         self.ui.rateComboBox.activated.connect(self.select_new_rate)
 
@@ -220,7 +218,7 @@ class LineBeamParametersControl(Display):
         """
         Handler for when the user selects a new rate using the combo box.
         """
-        self.update_rate_signal.emit(self.valid_rates[index])
+        self.update_rate_signal.emit(VALID_RATES[index])
 
     def update_rate_combobox_value(self, value):
         """
@@ -232,9 +230,5 @@ class LineBeamParametersControl(Display):
         If value is not a valid value, the combobox will display the
         nearest lowest valid value.
         """
-        chosen_rate = 0
-        for rate in self.valid_rates:
-            if value >= rate:
-                chosen_rate = rate
-                break
-        self.ui.rateComboBox.setCurrentIndex(self.valid_rates.index(chosen_rate))
+        valid_rate = get_valid_rate(value)
+        self.ui.rateComboBox.setCurrentIndex(VALID_RATES.index(valid_rate))

--- a/line_beam_parameters.py
+++ b/line_beam_parameters.py
@@ -31,6 +31,13 @@ class LineBeamParametersControl(Display):
     # Monitor the rate readback for use in the zero rate button
     rate_channel = None
 
+    # Signal to set a new rate from the combobox or from zero rate button
+    update_rate_signal = QtCore.Signal(int)
+
+    # List of valid rate selections from high to low in Hz
+    valid_rates = [120, 10, 1, 0]
+
+
     def __init__(self, parent=None, args=None, macros=None):
         super(LineBeamParametersControl, self).__init__(parent=parent,
                                                         args=args,
@@ -45,11 +52,17 @@ class LineBeamParametersControl(Display):
             self.destroyed.connect(functools.partial(clear_channel,
                                                      self.rate_channel))
 
+    def ui_filename(self):
+        return 'line_beam_parameters.ui'
+
     def setup_ui(self):
         self.setup_bits_connections()
         self.setup_bit_indicators()
         self.setup_energy_range_channel()
+        self.setup_rate_channel()
         self.setup_zero_rate()
+        self.setup_rate_combo()
+        self.rate_channel.connect()
 
     def setup_bits_connections(self):
         """
@@ -143,16 +156,19 @@ class LineBeamParametersControl(Display):
         # loop between this slot and the energy_range_signal signal.
         self._setting_bits = False
 
+    def setup_rate_channel(self):
+        prefix = self.config.get('line_arbiter_prefix')
+        self.rate_channel = PyDMChannel(
+            f'ca://{prefix}BeamParamCntl:ReqBP:Rate',
+            value_slot=self.watch_rate_update,
+            value_signal=self.update_rate_signal,
+        )
+
     def setup_zero_rate(self):
         self.ui.zeroRate.clicked.connect(self.set_zero_rate)
         self.ui.placeholder.hide()
         self.rate_req = None
         self.apply_attempts = 0
-        self.rate_channel = PyDMChannel(
-            self.ui.rateEdit.channel,
-            value_slot=self.watch_rate_update,
-        )
-        self.rate_channel.connect()
         self.zero_rate_timer = QtCore.QTimer()
         self.zero_rate_timer.timeout.connect(self.apply_zero_rate)
         self.zero_rate_timer.setSingleShot(True)
@@ -161,8 +177,12 @@ class LineBeamParametersControl(Display):
     def watch_rate_update(self, value):
         """
         Watch the rate channel so we know the most recent value.
+
+        This is also used to update the rate selection combobox on
+        one GUI after another GUI makes a selection.
         """
         self.rate_req = value
+        self.update_rate_combobox_value(value)
 
     def set_zero_rate(self):
         """
@@ -171,8 +191,7 @@ class LineBeamParametersControl(Display):
         Modify the rate edit, emit a signal for the apply step.
         """
         self.apply_attempts = 0
-        self.rateEdit.setText('0 Hz')
-        self.rateEdit.send_value()
+        self.update_rate_signal.emit(0)
         self.zero_rate_timer.start()
 
     def apply_zero_rate(self):
@@ -189,5 +208,33 @@ class LineBeamParametersControl(Display):
                 TimeoutError('Apply zero rate failed!')
             )
 
-    def ui_filename(self):
-        return 'line_beam_parameters.ui'
+    def setup_rate_combo(self):
+        """
+        Fill the combobox for rate selection and make it work.
+        """
+        for rate in self.valid_rates:
+            self.ui.rateComboBox.addItem(f'{rate} Hz')
+        self.ui.rateComboBox.activated.connect(self.select_new_rate)
+
+    def select_new_rate(self, index):
+        """
+        Handler for when the user selects a new rate using the combo box.
+        """
+        self.update_rate_signal.emit(self.valid_rates[index])
+
+    def update_rate_combobox_value(self, value):
+        """
+        Set the combobox to the index that corresponds with value.
+
+        This does not write to the PV, it just changes the visual
+        state of the combobox.
+
+        If value is not a valid value, the combobox will display the
+        nearest lowest valid value.
+        """
+        chosen_rate = 0
+        for rate in self.valid_rates:
+            if value >= rate:
+                chosen_rate = rate
+                break
+        self.ui.rateComboBox.setCurrentIndex(self.valid_rates.index(chosen_rate))

--- a/line_beam_parameters.ui
+++ b/line_beam_parameters.ui
@@ -14,8 +14,21 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="6" column="1">
-    <widget class="PyDMPushButton" name="PyDMPushButton">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_11">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Transmission:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="PyDMLineEdit" name="transEdit">
      <property name="enabled">
       <bool>false</bool>
      </property>
@@ -34,24 +47,44 @@
      <property name="toolTip">
       <string/>
      </property>
-     <property name="styleSheet">
-      <string notr="true">background-color: rgb(148, 255, 85);</string>
+     <property name="precision" stdset="0">
+      <number>2</number>
      </property>
-     <property name="text">
-      <string>Apply</string>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Apply</string>
-     </property>
-     <property name="showConfirmDialog" stdset="0">
+     <property name="showUnits" stdset="0">
       <bool>false</bool>
      </property>
-     <property name="pressValue" stdset="0">
-      <string>1</string>
+     <property name="precisionFromPV" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission</string>
+     </property>
+     <property name="displayFormat" stdset="0">
+      <enum>PyDMLineEdit::Exponential</enum>
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="1" column="0" colspan="4">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_13">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Photon Energy Ranges:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1" colspan="3">
     <widget class="QFrame" name="energy_range_frame">
      <property name="minimumSize">
       <size>
@@ -602,88 +635,7 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_13">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Photon Energy Ranges:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_15">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Rate:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_11">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Transmission:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="PyDMLineEdit" name="PyDMLineEdit_4">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>100</width>
-       <height>26</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>200</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="showUnits" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Rate</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="Line" name="line_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="2">
+   <item row="2" column="4">
     <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -696,44 +648,7 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </property>
     </spacer>
    </item>
-   <item row="0" column="1">
-    <widget class="PyDMLineEdit" name="PyDMLineEdit">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>100</width>
-       <height>26</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>200</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="precision" stdset="0">
-      <number>2</number>
-     </property>
-     <property name="showUnits" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="precisionFromPV" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission</string>
-     </property>
-     <property name="displayFormat" stdset="0">
-      <enum>PyDMLineEdit::Exponential</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
+   <item row="3" column="1" colspan="3">
     <layout class="QHBoxLayout" name="horizontalLayout_6">
      <property name="spacing">
       <number>0</number>
@@ -1681,7 +1596,7 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </item>
     </layout>
    </item>
-   <item row="3" column="2">
+   <item row="3" column="4">
     <spacer name="horizontalSpacer_2">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -1694,7 +1609,92 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </property>
     </spacer>
    </item>
-   <item row="7" column="0" colspan="2">
+   <item row="4" column="0" colspan="4">
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" rowspan="3">
+    <widget class="QLabel" name="label_15">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Rate:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1" rowspan="3">
+    <widget class="PyDMLineEdit" name="rateEdit">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>26</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Rate</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="PyDMPushButton" name="applyButton">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>26</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">background-color: rgb(148, 255, 85);</string>
+     </property>
+     <property name="text">
+      <string>Apply</string>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Apply</string>
+     </property>
+     <property name="showConfirmDialog" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="pressValue" stdset="0">
+      <string>1</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0" colspan="4">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -1706,6 +1706,50 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="5" column="2" rowspan="4">
+    <widget class="QPushButton" name="zeroRate">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>52</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>52</height>
+      </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">background-color: rgb(255, 85, 85);</string>
+     </property>
+     <property name="text">
+      <string>Zero Rate</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="3" rowspan="4">
+    <widget class="QPushButton" name="placeholder">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>52</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>52</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>[placeholder]</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/line_beam_parameters.ui
+++ b/line_beam_parameters.ui
@@ -27,616 +27,8 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="PyDMLineEdit" name="transEdit">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>100</width>
-       <height>26</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>200</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="precision" stdset="0">
-      <number>2</number>
-     </property>
-     <property name="showUnits" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="precisionFromPV" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission</string>
-     </property>
-     <property name="displayFormat" stdset="0">
-      <enum>PyDMLineEdit::Exponential</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="4">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_13">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Photon Energy Ranges:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1" colspan="3">
-    <widget class="QFrame" name="energy_range_frame">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>26</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="layoutDirection">
-      <enum>Qt::LeftToRight</enum>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::Panel</enum>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <property name="leftMargin">
-       <number>6</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QCheckBox" name="bit31">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit30">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit29">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit28">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit27">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit26">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit25">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit24">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit23">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit22">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit21">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit20">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit19">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit18">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit17">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit16">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit15">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit14">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit13">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit12">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit11">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit10">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit9">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit8">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit7">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit6">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit5">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit4">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit3">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit2">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit1">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit0">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="2" column="4">
-    <spacer name="horizontalSpacer">
+   <item row="3" column="4">
+    <spacer name="horizontalSpacer_2">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
@@ -647,6 +39,13 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="1" column="0" colspan="4">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
    </item>
    <item row="3" column="1" colspan="3">
     <layout class="QHBoxLayout" name="horizontalLayout_6">
@@ -1596,27 +995,7 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </item>
     </layout>
    </item>
-   <item row="3" column="4">
-    <spacer name="horizontalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="4" column="0" colspan="4">
-    <widget class="Line" name="line_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0" rowspan="3">
+   <item row="5" column="0" rowspan="2">
     <widget class="QLabel" name="label_15">
      <property name="font">
       <font>
@@ -1629,35 +1008,626 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </property>
     </widget>
    </item>
-   <item row="5" column="1" rowspan="3">
-    <widget class="PyDMLineEdit" name="rateEdit">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
+   <item row="5" column="2" rowspan="3">
+    <widget class="QPushButton" name="zeroRate">
      <property name="minimumSize">
       <size>
-       <width>100</width>
+       <width>0</width>
+       <height>52</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>52</height>
+      </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">background-color: rgb(255, 85, 85);</string>
+     </property>
+     <property name="text">
+      <string>Zero Rate</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="4">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_13">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Photon Energy Ranges:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="4">
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="4">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="1" colspan="3">
+    <widget class="QFrame" name="energy_range_frame">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
        <height>26</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>200</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
-     <property name="toolTip">
-      <string/>
+     <property name="layoutDirection">
+      <enum>Qt::LeftToRight</enum>
      </property>
-     <property name="showUnits" stdset="0">
-      <bool>true</bool>
+     <property name="frameShape">
+      <enum>QFrame::Panel</enum>
      </property>
-     <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Rate</string>
-     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QCheckBox" name="bit31">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit30">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit29">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit28">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit27">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit26">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit25">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit24">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit23">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit22">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit21">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit20">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit19">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit18">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit17">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit16">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit15">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit14">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit13">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit12">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit11">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit10">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit9">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit8">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit7">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit6">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit5">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit4">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit3">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit1">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit0">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
-   <item row="8" column="1">
+   <item row="7" column="1">
     <widget class="PyDMPushButton" name="applyButton">
      <property name="enabled">
       <bool>false</bool>
@@ -1694,42 +1664,44 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </property>
     </widget>
    </item>
-   <item row="9" column="0" colspan="4">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+   <item row="0" column="1">
+    <widget class="PyDMLineEdit" name="transEdit">
+     <property name="enabled">
+      <bool>false</bool>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="5" column="2" rowspan="4">
-    <widget class="QPushButton" name="zeroRate">
      <property name="minimumSize">
       <size>
-       <width>0</width>
-       <height>52</height>
+       <width>100</width>
+       <height>26</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>16777215</width>
-       <height>52</height>
+       <width>200</width>
+       <height>16777215</height>
       </size>
      </property>
-     <property name="styleSheet">
-      <string notr="true">background-color: rgb(255, 85, 85);</string>
+     <property name="toolTip">
+      <string/>
      </property>
-     <property name="text">
-      <string>Zero Rate</string>
+     <property name="precision" stdset="0">
+      <number>2</number>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="precisionFromPV" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission</string>
+     </property>
+     <property name="displayFormat" stdset="0">
+      <enum>PyDMLineEdit::Exponential</enum>
      </property>
     </widget>
    </item>
-   <item row="5" column="3" rowspan="4">
+   <item row="5" column="3" rowspan="3">
     <widget class="QPushButton" name="placeholder">
      <property name="enabled">
       <bool>true</bool>
@@ -1750,6 +1722,9 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       <string>[placeholder]</string>
      </property>
     </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QComboBox" name="rateComboBox"/>
    </item>
   </layout>
  </widget>

--- a/plc_ioc_status.ui
+++ b/plc_ioc_status.ui
@@ -57,7 +57,7 @@
         <height>204</height>
        </rect>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout_3"/>
+      <layout class="QGridLayout" name="gridLayout"/>
      </widget>
     </widget>
    </item>

--- a/pmps.py
+++ b/pmps.py
@@ -69,14 +69,25 @@ class PMPS(Display):
         self.setup_ui()
 
     def setup_ui(self):
-        dash_url = self.config.get('dashboard_url')
-        if dash_url:
-            self.ui.webbrowser.load(QtCore.QUrl(dash_url))
+        self.dash_url = self.config.get('dashboard_url')
+        self.web_open = False
+        if self.dash_url:
+            self.ui.tab_arbiter_outputs.currentChanged.connect(
+                self.open_webpage_if_tab,
+                )
 
         self.ui.btn_open_browser.clicked.connect(self.handle_open_browser)
 
         self.setup_ev_range_labels()
         self.setup_tabs()
+
+    def open_webpage_if_tab(self, tab_index):
+        if tab_index == 6 and not self.web_open:
+            self.ui.webbrowser.load(QtCore.QUrl(self.dash_url))
+            self.web_open = True
+        elif self.web_open:
+            self.ui.webbrowser.load(QtCore.QUrl('about:blank'))
+            self.web_open = False
 
     def setup_ev_range_labels(self):
         labels = list(range(7, 40))

--- a/preemptive_requests.py
+++ b/preemptive_requests.py
@@ -1,12 +1,14 @@
+import functools
 import json
 import typing
 from dataclasses import dataclass
+from string import Template
 
 from pydm import Display
 from pydm.widgets import PyDMByteIndicator, PyDMEmbeddedDisplay, PyDMLabel
 from pydm.widgets.channel import PyDMChannel
 from PyQt5.QtGui import QTableWidgetItem
-from qtpy import QtCore
+from qtpy import QtCore, QtWidgets
 
 
 class PreemptiveRequests(Display):
@@ -36,6 +38,9 @@ class PreemptiveRequests(Display):
       here, and instead we link the channels up with the QTableWidget.hideRow
       and QTableWidget.showRow methods.
     """
+    # The rates that are allowed to be asserted in pmps in Hz
+    valid_rates = [120, 10, 1, 0]
+
     def __init__(self, parent=None, args=None, macros=None):
         super().__init__(parent=parent, args=args, macros=macros)
         self.config = macros
@@ -84,6 +89,26 @@ class PreemptiveRequests(Display):
                 widget.filename = template
                 widget.loadWhenShown = False
                 widget.disconnectWhenHidden = False
+
+                # special setup for the rate label
+                # this is a plain QLabel so we can display true rate
+                # true rate is locked to one of a few fixed values
+                rate_label = widget.findChild(
+                    QtWidgets.QLabel,
+                    'rate_label',
+                )
+                rate_label.channel = Template(
+                    'ca://${P}${ARBITER}:AP:Entry:${POOL}:Rate_RBV'
+                ).safe_substitute(**macros)
+                rate_channel = PyDMChannel(
+                    rate_label.channel,
+                    value_slot=functools.partial(
+                        self.update_valid_rate,
+                        label=rate_label,
+                    ),
+                )
+                rate_channel.connect()
+                self._channels.append(rate_channel)
 
                 # insert the widget you see into the table
                 row_position = reqs_table.rowCount()
@@ -252,6 +277,14 @@ class PreemptiveRequests(Display):
         for row in range(self.row_count):
             self.update_filter(row)
 
+    def update_valid_rate(self, value, label):
+        chosen_rate = 0
+        for rate in self.valid_rates:
+            if value >= rate:
+                chosen_rate = rate
+                break
+        label.setText(f'{chosen_rate} Hz')
+
     def ui_filename(self):
         return 'preemptive_requests.ui'
 
@@ -388,7 +421,7 @@ item_info_list = [
         name='rate',
         select_text='Rate',
         widget_name='rate_label',
-        widget_class=PyDMLabel,
+        widget_class=QtWidgets.QLabel,
         store_type=int,
         data_type=int,
         default=0,

--- a/preemptive_requests.py
+++ b/preemptive_requests.py
@@ -10,6 +10,8 @@ from pydm.widgets.channel import PyDMChannel
 from PyQt5.QtGui import QTableWidgetItem
 from qtpy import QtCore, QtWidgets
 
+from data_bounds import get_valid_rate
+
 
 class PreemptiveRequests(Display):
     """
@@ -38,9 +40,6 @@ class PreemptiveRequests(Display):
       here, and instead we link the channels up with the QTableWidget.hideRow
       and QTableWidget.showRow methods.
     """
-    # The rates that are allowed to be asserted in pmps in Hz
-    valid_rates = [120, 10, 1, 0]
-
     def __init__(self, parent=None, args=None, macros=None):
         super().__init__(parent=parent, args=args, macros=macros)
         self.config = macros
@@ -278,12 +277,8 @@ class PreemptiveRequests(Display):
             self.update_filter(row)
 
     def update_valid_rate(self, value, label):
-        chosen_rate = 0
-        for rate in self.valid_rates:
-            if value >= rate:
-                chosen_rate = rate
-                break
-        label.setText(f'{chosen_rate} Hz')
+        valid_rate = get_valid_rate(value)
+        label.setText(f'{valid_rate} Hz')
 
     def ui_filename(self):
         return 'preemptive_requests.ui'

--- a/templates/preemptive_requests_entry.ui
+++ b/templates/preemptive_requests_entry.ui
@@ -132,6 +132,12 @@
        <height>16777215</height>
       </size>
      </property>
+     <property name="styleSheet">
+      <string notr="true">QLabel { color : black; }</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
     </widget>
    </item>
    <item>

--- a/templates/preemptive_requests_entry.ui
+++ b/templates/preemptive_requests_entry.ui
@@ -110,7 +110,7 @@
     </widget>
    </item>
    <item>
-    <widget class="PyDMLabel" name="rate_label">
+    <widget class="QLabel" name="rate_label">
      <property name="enabled">
       <bool>false</bool>
      </property>
@@ -131,15 +131,6 @@
        <width>100</width>
        <height>16777215</height>
       </size>
-     </property>
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="showUnits" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${P}${ARBITER}:AP:Entry:${POOL}:Rate_RBV</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
- Committed live configuration changes several times (I don't think these config files belong in the repo... there is some refactoring opportunities with the config files and with installing the launcher into the main conda environment)
- Only open the Grafana web page when the tab is opened, and close it when the tab is closed. This helps with the memory management a bit (I think), and it stops us from seeing the javascript errors when not using the grafana logs.
- Compatibility with pydm=1.11.1 rules enum handling (note: will probably need to revert this commit in a follow-up PR after the next PyDM tag, or flip an option or osmething)
- Add a "zero-rate" button to the line beam parameters tab that kills the beam ASAP
- Instead of showing an "Invalid" PV at 0 cycle counts for unused tasks on a PLC, hide those widgets.
- Add an indicator on the fast faults tab for how far ahead or behind the arbiter's clock is
- Limit the line beam parameter rate selection options to the ones that can take effect in the real system
- Limit the pre-emptive request beam rate visual readbacks to the ones that are effective in the real system 