### PR TITLE
ENH: start with a simple not-ok filter to speed up initial rendering

### DIFF
--- a/fast_faults.ui
+++ b/fast_faults.ui
@@ -118,7 +118,7 @@
             <bool>true</bool>
            </property>
            <property name="checked">
-            <bool>false</bool>
+            <bool>true</bool>
            </property>
            <layout class="QHBoxLayout" name="horizontalLayout_4">
             <property name="spacing">


### PR DESCRIPTION
Functionally, apply a "only show faults that are not OK" filter on first load.

This results in a marginal speedup on startup because we don't do some of the initial rendering etc. on fast faults that aren't going to be shown anyway after the user inevitably applies a filter.

The first time a particular fault shows up can still be slow.

"OK: False" was picked over "Beam Permitted: False" because it'll show things like bypasses.