### PR TITLE
FIX: use the beam ctrl rbv PVs instead of the global PVs

### DIFF
--- a/line_beam_parameters.ui
+++ b/line_beam_parameters.ui
@@ -1145,7 +1145,7 @@
       <string/>
      </property>
      <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}RequestedBP:Rate_RBV</string>
+      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Rate_RBV</string>
      </property>
     </widget>
    </item>
@@ -1230,7 +1230,7 @@
       <string/>
      </property>
      <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}RequestedBP:Transmission_RBV</string>
+      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission_RBV</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Slight modification to the readbacks added to the line beam parameters tab in #63

It seems like these were actually pointing to the global readbacks for rate and transmission, rather than to the line beam parameter setting readbacks. These are often exactly the same but sometimes they are not which can lead to some confusion.

No changes to the layout etc. introduced in the previous PR.

Original jira: https://jira.slac.stanford.edu/browse/LCLSECSD-412
closes #69 which was originally observed by Maggie