### PR TITLE
ENH: switch default filter to no beam instead of not ok

### DIFF
--- a/fast_faults.ui
+++ b/fast_faults.ui
@@ -118,7 +118,7 @@
             <bool>true</bool>
            </property>
            <property name="checked">
-            <bool>true</bool>
+            <bool>false</bool>
            </property>
            <layout class="QHBoxLayout" name="horizontalLayout_4">
             <property name="spacing">
@@ -162,7 +162,7 @@
             <bool>true</bool>
            </property>
            <property name="checked">
-            <bool>false</bool>
+            <bool>true</bool>
            </property>
            <layout class="QHBoxLayout" name="horizontalLayout_5">
             <property name="spacing">


### PR DESCRIPTION
In #68 I opted to start the GUI with a "not OK" filter, but this was a mistake because it misses fast faults that are active and ready to be acknowledged and cleared.

This PR starts with a "no beam" filter, which is the most common use of this screen.

Overall this has the same performance impact as the other PR: initial startup has no gap between "I see the screen" and "I can click buttons", but the process of getting to seeing the screen is still slow.