### PR TITLE
ENH: clean up the arbiter output page layout

### DIFF
--- a/arbiter_outputs.py
+++ b/arbiter_outputs.py
@@ -40,6 +40,7 @@ class ArbiterOutputs(Display):
                 widget.macros = json.dumps(macros)
                 widget.filename = template
                 widget.disconnectWhenHidden = False
+                widget.setMinimumHeight(40)
                 outs_container.layout().addWidget(widget)
                 count += 1
         print(f'Added {count} arbiter outputs')

--- a/arbiter_outputs.ui
+++ b/arbiter_outputs.ui
@@ -176,8 +176,8 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>676</width>
-           <height>163</height>
+           <width>675</width>
+           <height>185</height>
           </rect>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_3">

--- a/templates/arbiter_outputs_entry.ui
+++ b/templates/arbiter_outputs_entry.ui
@@ -25,7 +25,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,2,0">
+  <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,2">
    <property name="spacing">
     <number>0</number>
    </property>
@@ -41,6 +41,43 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
+   <item alignment="Qt::AlignVCenter">
+    <widget class="PyDMByteIndicator" name="PyDMByteIndicator_3">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>80</width>
+       <height>32</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>80</width>
+       <height>32</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${P}FFO:${FFO}:FaultHWO_RBV</string>
+     </property>
+     <property name="showLabels" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="circles" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
    <item>
     <widget class="QLabel" name="label">
      <property name="minimumSize">
@@ -79,43 +116,6 @@
      </property>
      <property name="channel" stdset="0">
       <string>ca://${P}FFO:${FFO}:FaultHWO_RBV.DESC</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="PyDMByteIndicator" name="PyDMByteIndicator_3">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>80</width>
-       <height>32</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>80</width>
-       <height>32</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${P}FFO:${FFO}:FaultHWO_RBV</string>
-     </property>
-     <property name="showLabels" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="circles" stdset="0">
-      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/templates/arbiter_outputs_header.ui
+++ b/templates/arbiter_outputs_header.ui
@@ -48,10 +48,57 @@
     <number>0</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,2,0,0">
+    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,0,2,0">
      <property name="spacing">
       <number>0</number>
      </property>
+     <item>
+      <widget class="QLabel" name="label_7">
+       <property name="minimumSize">
+        <size>
+         <width>80</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Value</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="wordWrap">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>30</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
      <item>
       <widget class="QLabel" name="label_5">
        <property name="minimumSize">
@@ -68,6 +115,9 @@
        </property>
        <property name="text">
         <string>PV</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
        </property>
       </widget>
      </item>
@@ -108,37 +158,6 @@
         </size>
        </property>
       </spacer>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_7">
-       <property name="minimumSize">
-        <size>
-         <width>80</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>80</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>Value</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-       </property>
-       <property name="wordWrap">
-        <bool>false</bool>
-       </property>
-      </widget>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
- Move the arbiter output status from the far right over to the left, next to the PV name for easier scanning
- Nitpick alignment of header text
- Fix vertical clipping issue
- closes #54

Before:
![image](https://user-images.githubusercontent.com/10647860/180895095-d3fe5c38-51ba-442a-a718-7d2c7b5dd06b.png)


After:
![image](https://user-images.githubusercontent.com/10647860/180894988-c3b7f2f6-0f78-4b7f-93af-4ed54c6376eb.png)
