### PR TITLE
MAINT: Change chemRIXS vac PMPS PVs to now use CRIXS preface

### DIFF
--- a/KFE_config.yml
+++ b/KFE_config.yml
@@ -64,7 +64,7 @@ fastfaults:
     ff_start: 1
     ff_end: 100
 
-  - prefix: "PLC:CRIX:VAC:"
+  - prefix: "PLC:CRIXS:VAC:"
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
@@ -153,7 +153,7 @@ preemptive_requests:
     assertion_pool_start: 1
     assertion_pool_end: 20
 
-  - prefix: "PLC:CRIX:VAC:"
+  - prefix: "PLC:CRIXS:VAC:"
     arbiter_instance: "ARB:01"
     assertion_pool_start: 1
     assertion_pool_end: 20


### PR DESCRIPTION
chemRIXS vacuum PVs are going to be using CRIXS as a preface now, rather than CRIX. This will apply to CRIXS VAC PMPS PVs as well:

![image](https://user-images.githubusercontent.com/100723754/188026879-e5c72392-0908-4455-82e2-7476d47f0700.png)
