### PR TITLE
ENH: add script for synchronizing pmps-ui with ACR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Sync log
+sync_log.txt
+
 # PyTest Cache
 .pytest_cache
 

--- a/nfs_afs_sync.sh
+++ b/nfs_afs_sync.sh
@@ -8,6 +8,8 @@ DEST="/afs/slac/g/lcls/tools/pydm/display/xray/pmps-ui"
 echo "Sync at $(date)" >> "${LOG}"
 echo "from ${SOURCE}" >> "${LOG}"
 echo "to ${DEST}" >> "${LOG}"
+# Pick up permissions to write to afs
+aklog
 # Avoid git repo + random junk like screenshots
 rsync -rv ${SOURCE}/*.py ${SOURCE}/*.ui ${SOURCE}/*.yml ${SOURCE}/*.sh ${SOURCE}/templates "${DEST}" >> "${LOG}"
 echo "---------------------------" >> "${LOG}"

--- a/nfs_afs_sync.sh
+++ b/nfs_afs_sync.sh
@@ -8,8 +8,8 @@ DEST="/afs/slac/g/lcls/tools/pydm/display/xray/pmps-ui"
 echo "Sync at $(date)" | tee -a "${LOG}"
 echo "from ${SOURCE}" | tee -a "${LOG}"
 echo "to ${DEST}" | tee -a "${LOG}"
-# Pick up permissions to write to afs
-aklog 2>&1 | tee -a "${LOG}"
+# Pick up permissions to write to afs (in case user hasn't done aklog yet)
+aklog -d 2>&1 | tee -a "${LOG}"
 # Avoid git repo + random junk like screenshots
 rsync -rv ${SOURCE}/*.py ${SOURCE}/*.ui ${SOURCE}/*.yml ${SOURCE}/*.sh ${SOURCE}/templates "${DEST}" 2>&1 | tee -a "${LOG}"
 echo "---------------------------" >> "${LOG}"

--- a/nfs_afs_sync.sh
+++ b/nfs_afs_sync.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# rsync the files in the deployed directory to afs to be picked up by acr
+LOG="$(readlink -f $(dirname -- ${BASH_SOURCE[0]}))/sync_log.txt"
+SOURCE="/cds/group/pcds/epics-dev/screens/pydm/pmps-ui"
+DEST="/afs/slac/g/lcls/tools/pydm/display/xray/pmps-ui"
+
+echo "Sync at $(date)" >> "${LOG}"
+echo "from ${SOURCE}" >> "${LOG}"
+echo "to ${DEST}" >> "${LOG}"
+# Avoid git repo + random junk like screenshots
+rsync -rv ${SOURCE}/*.py ${SOURCE}/*.ui ${SOURCE}/*.yml ${SOURCE}/*.sh ${SOURCE}/*.sh ${SOURCE}/templates "${DEST}" >> "${LOG}"
+echo "---------------------------" >> ${LOG}

--- a/nfs_afs_sync.sh
+++ b/nfs_afs_sync.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # rsync the files in the deployed directory to afs to be picked up by acr
-LOG="$(readlink -f $(dirname -- ${BASH_SOURCE[0]}))/sync_log.txt"
+LOG="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")/sync_log.txt"
 SOURCE="/cds/group/pcds/epics-dev/screens/pydm/pmps-ui"
 DEST="/afs/slac/g/lcls/tools/pydm/display/xray/pmps-ui"
 
@@ -9,4 +9,4 @@ echo "from ${SOURCE}" >> "${LOG}"
 echo "to ${DEST}" >> "${LOG}"
 # Avoid git repo + random junk like screenshots
 rsync -rv ${SOURCE}/*.py ${SOURCE}/*.ui ${SOURCE}/*.yml ${SOURCE}/*.sh ${SOURCE}/*.sh ${SOURCE}/templates "${DEST}" >> "${LOG}"
-echo "---------------------------" >> ${LOG}
+echo "---------------------------" >> "${LOG}"

--- a/nfs_afs_sync.sh
+++ b/nfs_afs_sync.sh
@@ -9,7 +9,7 @@ echo "Sync at $(date)" | tee -a "${LOG}"
 echo "from ${SOURCE}" | tee -a "${LOG}"
 echo "to ${DEST}" | tee -a "${LOG}"
 # Pick up permissions to write to afs
-aklog
+aklog 2>&1 | tee -a "${LOG}"
 # Avoid git repo + random junk like screenshots
 rsync -rv ${SOURCE}/*.py ${SOURCE}/*.ui ${SOURCE}/*.yml ${SOURCE}/*.sh ${SOURCE}/templates "${DEST}" 2>&1 | tee -a "${LOG}"
 echo "---------------------------" >> "${LOG}"

--- a/nfs_afs_sync.sh
+++ b/nfs_afs_sync.sh
@@ -5,11 +5,11 @@ LOG="${HERE}/sync_log.txt"
 SOURCE="${HERE}"
 DEST="/afs/slac/g/lcls/tools/pydm/display/xray/pmps-ui"
 
-echo "Sync at $(date)" >> "${LOG}"
-echo "from ${SOURCE}" >> "${LOG}"
-echo "to ${DEST}" >> "${LOG}"
+echo "Sync at $(date)" | tee -a "${LOG}"
+echo "from ${SOURCE}" | tee -a "${LOG}"
+echo "to ${DEST}" | tee -a "${LOG}"
 # Pick up permissions to write to afs
 aklog
 # Avoid git repo + random junk like screenshots
-rsync -rv ${SOURCE}/*.py ${SOURCE}/*.ui ${SOURCE}/*.yml ${SOURCE}/*.sh ${SOURCE}/templates "${DEST}" >> "${LOG}"
+rsync -rv ${SOURCE}/*.py ${SOURCE}/*.ui ${SOURCE}/*.yml ${SOURCE}/*.sh ${SOURCE}/templates "${DEST}" 2>&1 | tee -a "${LOG}"
 echo "---------------------------" >> "${LOG}"

--- a/nfs_afs_sync.sh
+++ b/nfs_afs_sync.sh
@@ -8,5 +8,5 @@ echo "Sync at $(date)" >> "${LOG}"
 echo "from ${SOURCE}" >> "${LOG}"
 echo "to ${DEST}" >> "${LOG}"
 # Avoid git repo + random junk like screenshots
-rsync -rv ${SOURCE}/*.py ${SOURCE}/*.ui ${SOURCE}/*.yml ${SOURCE}/*.sh ${SOURCE}/*.sh ${SOURCE}/templates "${DEST}" >> "${LOG}"
+rsync -rv ${SOURCE}/*.py ${SOURCE}/*.ui ${SOURCE}/*.yml ${SOURCE}/*.sh ${SOURCE}/templates "${DEST}" >> "${LOG}"
 echo "---------------------------" >> "${LOG}"

--- a/nfs_afs_sync.sh
+++ b/nfs_afs_sync.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # rsync the files in the deployed directory to afs to be picked up by acr
-LOG="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")/sync_log.txt"
-SOURCE="/cds/group/pcds/epics-dev/screens/pydm/pmps-ui"
+HERE="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
+LOG="${HERE}/sync_log.txt"
+SOURCE="${HERE}"
 DEST="/afs/slac/g/lcls/tools/pydm/display/xray/pmps-ui"
 
 echo "Sync at $(date)" >> "${LOG}"


### PR DESCRIPTION
The intention is to point a cron job to the deployed version of this script to keep ACR updated when we update the LFE/KFE configurations, so that when this UI is opened in ACR (without tunneling) the configuration is maximally up-to-date.

I've opted not to sync the random svg files and other junk that has accumulated in the deployed folder.