### PR TITLE
ENH: improve the ACR sync cron QOL

### DIFF
--- a/nfs_afs_sync.sh
+++ b/nfs_afs_sync.sh
@@ -9,4 +9,4 @@ echo "from ${SOURCE}"
 echo "to ${DEST}"
 # Avoid git repo + random junk like screenshots
 rsync -rv ${SOURCE}/*.py ${SOURCE}/*.ui ${SOURCE}/*.yml ${SOURCE}/*.sh ${SOURCE}/templates "${DEST}"
-echo "---------------------------" >> "${LOG}"
+echo "---------------------------"

--- a/nfs_afs_sync.sh
+++ b/nfs_afs_sync.sh
@@ -1,15 +1,12 @@
 #!/bin/bash
 # rsync the files in the deployed directory to afs to be picked up by acr
 HERE="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
-LOG="${HERE}/sync_log.txt"
 SOURCE="${HERE}"
 DEST="/afs/slac/g/lcls/tools/pydm/display/xray/pmps-ui"
 
-echo "Sync at $(date)" | tee -a "${LOG}"
-echo "from ${SOURCE}" | tee -a "${LOG}"
-echo "to ${DEST}" | tee -a "${LOG}"
-# Pick up permissions to write to afs (in case user hasn't done aklog yet)
-aklog -d 2>&1 | tee -a "${LOG}"
+echo "Sync at $(date)"
+echo "from ${SOURCE}"
+echo "to ${DEST}"
 # Avoid git repo + random junk like screenshots
-rsync -rv ${SOURCE}/*.py ${SOURCE}/*.ui ${SOURCE}/*.yml ${SOURCE}/*.sh ${SOURCE}/templates "${DEST}" 2>&1 | tee -a "${LOG}"
+rsync -rv ${SOURCE}/*.py ${SOURCE}/*.ui ${SOURCE}/*.yml ${SOURCE}/*.sh ${SOURCE}/templates "${DEST}"
 echo "---------------------------" >> "${LOG}"

--- a/sync_cron.sh
+++ b/sync_cron.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# run the rsync and log it properly for cron
+HERE="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")")"
+LOG="${HERE}/sync_log.txt"
+SCRIPT="${HERE}/nfs_afs_sync.sh"
+
+# Stdout and stderr must both go to the logfile
+# Stderr must also go to the screen to trigger the cron email
+# Stdout must not go to the screen to avoid the cron email
+# 2>&1 redirects stderr to stdout so it goes through the pipe to tee's stdin
+# >> redirects stdout (without stderr) to the logfile in append mode so it does not go through the pipe
+${SCRIPT} 2>&1 1>>"${LOG}" | tee -a "${LOG}"


### PR DESCRIPTION
- script is easier to read now
- second script is used to manage stdout/stderr/logfile
- a cron daemon email is only sent on failure since only stderr makes it to terminal now