### PR TITLE
MAINT: scripted fix for precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     -   id: debug-statements
 
 # Too many errors to fix on a Friday, to be re-enabled later
-#-   repo: https://gitlab.com/pycqa/flake8.git
+#-   repo: https://github.com/pycqa/flake8.git
 #    rev: 3.9.0
 #    hooks:
 #    -   id: flake8


### PR DESCRIPTION
PR generated from script to fix .pre-commit-config.yaml in all repos, switching out the missing flake8 gitlab mirror for github.