### PR TITLE
ENH: updates for SC

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+exclude = .git,__pycache__,build,dist,versioneer.py,pmpsdb_client/_version.py,docs/*
+max-line-length = 88
+select = C,E,F,W,B,B950
+extend-ignore = E203, E501

--- a/KFE_config.yml
+++ b/KFE_config.yml
@@ -1,5 +1,6 @@
 line_arbiter_prefix: "PMPS:KFE:"
 undulator_kicker_rate_pv: "IOC:BSY0:MP01:BYKIKS_RATE"
+accelerator_mode_pv: "SIOC:FEES:MP01:LCLSMODE_RBV"
 
 dashboard_url: "http://ctl-logsrv01:3000/ctl/grafana/d/PRr2cuGGz/k-pmps-events?viewPanel=2&orgId=1&refresh=10s&kiosk"
 

--- a/LFE_config.yml
+++ b/LFE_config.yml
@@ -1,5 +1,6 @@
 line_arbiter_prefix: "PMPS:LFE:"
 undulator_kicker_rate_pv: "IOC:BSY0:MP01:BYKIK_RATE"
+accelerator_mode_pv: "SIOC:FEEH:MP01:LCLSMODE_RBV"
 
 dashboard_url: "http://ctl-logsrv01:3000/ctl/grafana/d/PQBzCnmMz/l-pmps-events?refresh=10s&kiosk"
 

--- a/LFE_config.yml
+++ b/LFE_config.yml
@@ -58,21 +58,6 @@ preemptive_requests:
     assertion_pool_start: 1
     assertion_pool_end: 20
 
-  - prefix: "EM1L0:GEM:"
-    arbiter_instance: "ARB:01"
-    assertion_pool_start: 1
-    assertion_pool_end: 20
-
-  - prefix: "EM1L0:GEM:"
-    arbiter_instance: "ARB:02"
-    assertion_pool_start: 1
-    assertion_pool_end: 20
-
-  - prefix: "EM1L0:GEM:"
-    arbiter_instance: "ARB:03"
-    assertion_pool_start: 1
-    assertion_pool_end: 20
-
   - prefix: "PLC:XRT:HOMS:"
     arbiter_instance: "ARB:01"
     assertion_pool_start: 1

--- a/TST_config.yml
+++ b/TST_config.yml
@@ -1,5 +1,6 @@
 line_arbiter_prefix: "PMPS:LFE:"
 undulator_kicker_rate_pv: "IOC:BSY0:MP01:BYKIK_RATE"
+accelerator_mode_pv: "SIOC:FEEH:MP01:LCLSMODE_RBV"
 
 dashboard_url: "http://ctl-logsrv01:3000/ctl/grafana/d/PQBzCnmMz/l-pmps-events?refresh=10s&kiosk"
 

--- a/arbiter_outputs.py
+++ b/arbiter_outputs.py
@@ -2,18 +2,52 @@ import json
 
 from pydm import Display
 from pydm.widgets import PyDMEmbeddedDisplay
-from qtpy import QtWidgets
+from pydm.widgets.channel import PyDMChannel
+
+from beamclass_table import get_tooltip_for_bc, install_bc_setText
 
 
 class ArbiterOutputs(Display):
 
     def __init__(self, parent=None, args=None, macros=None):
-        super(ArbiterOutputs, self).__init__(parent=parent, args=args, macros=macros)
+        super().__init__(parent=parent, args=args, macros=macros)
         self.config = macros
+        self._channels = []
         self.setup_ui()
 
     def setup_ui(self):
         self.setup_outputs()
+        self.setup_bitmask_summaries()
+
+    def setup_bitmask_summaries(self):
+        install_bc_setText(self.ui.bc_summary_label)
+        bc_channel = PyDMChannel(
+            self.ui.bc_bytes.channel,
+            value_slot=self.update_bc_summary,
+        )
+        bc_channel.connect()
+        self._channels.append(bc_channel)
+        rate_channel = PyDMChannel(
+            self.ui.rate_bytes.channel,
+            value_slot=self.update_rate_summary,
+        )
+        rate_channel.connect()
+        self._channels.append(rate_channel)
+
+    def update_bc_summary(self, value):
+        self.ui.bc_summary_label.setText(value)
+        self.ui.bc_summary_label.setToolTip(get_tooltip_for_bc(value))
+
+    def update_rate_summary(self, value):
+        if value >> 2 & 1:
+            rate = 120
+        elif value >> 1 & 1:
+            rate = 10
+        elif value & 1:
+            rate = 1
+        else:
+            rate = 0
+        self.ui.rate_summary_label.setText(f'{rate} Hz')
 
     def setup_outputs(self):
         ffs = self.config.get('fastfaults')
@@ -44,6 +78,9 @@ class ArbiterOutputs(Display):
                 outs_container.layout().addWidget(widget)
                 count += 1
         print(f'Added {count} arbiter outputs')
+
+    def channels(self):
+        return self._channels
 
     def ui_filename(self):
         return 'arbiter_outputs.ui'

--- a/arbiter_outputs.py
+++ b/arbiter_outputs.py
@@ -4,7 +4,8 @@ from pydm import Display
 from pydm.widgets import PyDMEmbeddedDisplay
 from pydm.widgets.channel import PyDMChannel
 
-from beamclass_table import get_tooltip_for_bc, install_bc_setText
+from beamclass_table import install_bc_setText
+from tooltips import get_tooltip_for_bc
 
 
 class ArbiterOutputs(Display):

--- a/arbiter_outputs.ui
+++ b/arbiter_outputs.ui
@@ -19,7 +19,7 @@
      <item>
       <layout class="QHBoxLayout" name="horizontalLayout_2">
        <item>
-        <widget class="PyDMByteIndicator" name="PyDMByteIndicator_3">
+        <widget class="PyDMByteIndicator" name="bc_bytes">
          <property name="enabled">
           <bool>false</bool>
          </property>
@@ -33,18 +33,14 @@
           <enum>Qt::Vertical</enum>
          </property>
          <property name="numBits" stdset="0">
-          <number>8</number>
+          <number>4</number>
          </property>
          <property name="labels" stdset="0">
           <stringlist>
-           <string>Channel 01 - BC_1HZ</string>
-           <string>Channel 02 - BC_10HZ</string>
-           <string>Channel 03 - BC_FULL</string>
-           <string>Channel 04 - BC_FULL</string>
-           <string>Channel 05 - BC_FULL</string>
-           <string>Channel 06 - BC_FULL</string>
-           <string>Channel 07 - BC_FULL</string>
-           <string>Channel 08 - BC_FULL</string>
+           <string>Channel 01 - BC Bit 0 (LSB)</string>
+           <string>Channel 02 - BC Bit 1</string>
+           <string>Channel 03 - BC Bit 2</string>
+           <string>Channel 04 - BC Bit 3 (MSB)</string>
           </stringlist>
          </property>
         </widget>
@@ -65,9 +61,16 @@
       </layout>
      </item>
      <item>
+      <widget class="QLabel" name="bc_summary_label">
+       <property name="text">
+        <string>Loading...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <layout class="QHBoxLayout" name="horizontalLayout_3">
        <item>
-        <widget class="PyDMByteIndicator" name="PyDMByteIndicator_4">
+        <widget class="PyDMByteIndicator" name="rate_bytes">
          <property name="enabled">
           <bool>false</bool>
          </property>
@@ -106,6 +109,13 @@
         </spacer>
        </item>
       </layout>
+     </item>
+     <item>
+      <widget class="QLabel" name="rate_summary_label">
+       <property name="text">
+        <string>Loading...</string>
+       </property>
+      </widget>
      </item>
      <item>
       <spacer name="verticalSpacer_2">
@@ -176,7 +186,7 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>675</width>
+           <width>648</width>
            <height>185</height>
           </rect>
          </property>

--- a/beamclass_table.py
+++ b/beamclass_table.py
@@ -1,6 +1,9 @@
+from functools import partial
+from typing import Callable
+
 import prettytable
 from pydm import Display
-from qtpy.QtWidgets import QTableWidgetItem
+from qtpy.QtWidgets import QLabel, QTableWidgetItem
 
 
 class BeamclassTable(Display):
@@ -83,3 +86,23 @@ def get_desc_for_bc(beamclass: int) -> str:
     Get just the short description of a beamclass.
     """
     return bc_table[beamclass][1]
+
+
+def install_bc_setText(widget: QLabel):
+    """
+    Replace QLabel.setText to get the description too.
+
+    Without this, the labels display:
+    13
+    With this, you get:
+    13: Unlimited
+    """
+    def bc_setText(text: str) -> None:
+        try:
+            text = f'{text}: {get_desc_for_bc(int(text))}'
+        except Exception:
+            pass
+        return widget._original_setText(text)
+
+    widget._original_setText = widget.setText
+    widget.setText = bc_setText

--- a/beamclass_table.py
+++ b/beamclass_table.py
@@ -1,4 +1,3 @@
-import prettytable
 from pydm import Display
 from qtpy.QtWidgets import QLabel, QTableWidgetItem
 
@@ -55,43 +54,6 @@ bc_table = """
 """.strip().split('\n')
 for index, row in enumerate(bc_table):
     bc_table[index] = row.split('\t')
-
-
-def get_full_bc_table() -> str:
-    """
-    Show the full table
-    """
-    table = prettytable.PrettyTable()
-    table.field_names = bc_header
-    for row in bc_table:
-        table.add_row(row)
-    return str(table)
-
-
-def get_tooltip_for_bc(beamclass: int) -> str:
-    """
-    Create a mini 2-row table suitable for a beam class tooltip.
-    """
-    table = prettytable.PrettyTable()
-    table.field_names = bc_header
-    table.add_row(bc_table[beamclass])
-    return '<pre>' + str(table) + '</pre>'
-
-
-def get_tooltip_for_bc_bitmask(bitmask: int) -> str:
-    """
-    Create a partial table suitable for a bitmask tooltip.
-    """
-    table = prettytable.PrettyTable()
-    table.field_names = bc_header
-    table.add_row(bc_table[0])
-    count = 0
-    while bitmask > 0:
-        count += 1
-        if bitmask % 2:
-            table.add_row(bc_table[count])
-        bitmask = bitmask >> 1
-    return '<pre>' + str(table) + '</pre>'
 
 
 def get_desc_for_bc(beamclass: int) -> str:

--- a/beamclass_table.py
+++ b/beamclass_table.py
@@ -1,6 +1,3 @@
-from functools import partial
-from typing import Callable
-
 import prettytable
 from pydm import Display
 from qtpy.QtWidgets import QLabel, QTableWidgetItem
@@ -81,6 +78,22 @@ def get_tooltip_for_bc(beamclass: int) -> str:
     return '<pre>' + str(table) + '</pre>'
 
 
+def get_tooltip_for_bc_bitmask(bitmask: int) -> str:
+    """
+    Create a partial table suitable for a bitmask tooltip.
+    """
+    table = prettytable.PrettyTable()
+    table.field_names = bc_header
+    table.add_row(bc_table[0])
+    count = 0
+    while bitmask > 0:
+        count += 1
+        if bitmask % 2:
+            table.add_row(bc_table[count])
+        bitmask = bitmask >> 1
+    return '<pre>' + str(table) + '</pre>'
+
+
 def get_desc_for_bc(beamclass: int) -> str:
     """
     Get just the short description of a beamclass.
@@ -106,3 +119,16 @@ def install_bc_setText(widget: QLabel):
 
     widget._original_setText = widget.setText
     widget.setText = bc_setText
+
+
+def get_max_bc_from_bitmask(bitmask: int) -> int:
+    """
+    Given a beamclass bitmask, get the highest non-spare beamclass.
+    """
+    max_bc = 0
+    while bitmask > 0:
+        bitmask = bitmask >> 1
+        max_bc += 1
+    while bc_table[max_bc][1] == 'Spare':
+        max_bc -= 1
+    return max_bc

--- a/beamclass_table.py
+++ b/beamclass_table.py
@@ -1,0 +1,78 @@
+import prettytable
+from pydm import Display
+from qtpy.QtWidgets import QTableWidgetItem
+
+
+class BeamclassTable(Display):
+    """
+    The Display that handles the beamclass table tab.
+
+    This is a static, informative display.
+    """
+    def __init__(self, parent=None, args=None, macros=None):
+        super().__init__(parent=parent, args=args, macros=macros)
+        self.setup_ui()
+
+    def setup_ui(self):
+        """Do all steps to prepare the inner workings of the display."""
+        self.ui.table.setColumnCount(len(bc_header))
+        self.ui.table.setRowCount(len(bc_table))
+        self.ui.table.setHorizontalHeaderLabels(bc_header)
+        for row_index, row_list in enumerate(bc_table):
+            for col_index, text in enumerate(row_list):
+                self.ui.table.setItem(
+                    row_index,
+                    col_index,
+                    QTableWidgetItem(text),
+                )
+        self.ui.table.resizeColumnsToContents()
+
+    def ui_filename(self):
+        return 'beamclass_table.ui'
+
+
+# Copied from https://confluence.slac.stanford.edu/pages/viewpage.action?pageId=341246543 and tweaked
+bc_header = """
+Index	Display Name	∆T (s)	dt (s)	Q (pC)	Rate max (Hz)	Current (nA)	Power @ 4 GeV (W)	Int. Energy @ 4 GeV (J)	Notes
+""".strip().split('\t')
+bc_table = """
+0	Beam Off	0.5	-	0	0	0	0	0	Beam off, Kickers off
+1	Kicker STBY	0.5	-	0	0	0	0	0	Beam off, Kickers standby
+2	BC1Hz	1	1	350	1	0.35	1.4	1.4	350 pC x 1 Hz
+3	BC10Hz	1	0.1	3500	10	3.5	14	14	350 pC X 10 Hz
+4	Diagnostic	0.5	-	5000	-	10	40	20	50 pC x 200 Hz
+5	BC120Hz	0.2	0.0083	6000	120	30	120	24	250 pC x 120 Hz
+6	Tuning	0.2	-	7000	-	35	140	28	100 pC X 350 Hz
+7	1% MAP	0.01	-	3000	-	300	1200	12	100 pC X 3 kHz
+8	5% MAP	0.003	-	4500	-	1500	6000	18	100 pC x 15 kHz
+9	10% MAP	0.001	-	3000	-	3000	12000	12	100 pC X 30 kHz
+10	25% MAP	4e-4	-	3000	-	7500	30000	12	100 pC x 75 kHz
+11	50% MAP	2e-1	-	3000	-	15000	60000	12	100 pC x 150 kHz
+12	100% MAP	2e-4	-	6000	-	30000	120000	24	100 pC x 300 kHz
+13	Unlimited	-	-	-	-	-	-	-	-
+14	Spare	-	-	-	-	-	-	-	-
+15	Spare	-	-	-	-	-	-	-	-
+""".strip().split('\n')
+for index, row in enumerate(bc_table):
+    bc_table[index] = row.split('\t')
+
+
+def get_full_bc_table() -> str:
+    """
+    Show the full table
+    """
+    table = prettytable.PrettyTable()
+    table.field_names = bc_header
+    for row in bc_table:
+        table.add_row(row)
+    return str(table)
+
+
+def get_tooltip_for_bc(beamclass: int) -> str:
+    """
+    Create a mini 2-row table suitable for a beam class tooltip.
+    """
+    table = prettytable.PrettyTable()
+    table.field_names = bc_header
+    table.add_row(bc_table[beamclass])
+    return str(table)

--- a/beamclass_table.py
+++ b/beamclass_table.py
@@ -75,4 +75,11 @@ def get_tooltip_for_bc(beamclass: int) -> str:
     table = prettytable.PrettyTable()
     table.field_names = bc_header
     table.add_row(bc_table[beamclass])
-    return str(table)
+    return '<pre>' + str(table) + '</pre>'
+
+
+def get_desc_for_bc(beamclass: int) -> str:
+    """
+    Get just the short description of a beamclass.
+    """
+    return bc_table[beamclass][1]

--- a/beamclass_table.ui
+++ b/beamclass_table.ui
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTableWidget" name="table">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="rowCount">
+      <number>5</number>
+     </property>
+     <property name="columnCount">
+      <number>5</number>
+     </property>
+     <attribute name="horizontalHeaderVisible">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <row/>
+     <row/>
+     <row/>
+     <row/>
+     <row/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/grafana_log_display.py
+++ b/grafana_log_display.py
@@ -16,7 +16,7 @@ class GrafanaLogDisplay(Display):
         self.ui.btn_open_browser.clicked.connect(self.handle_open_browser)
 
     def open_webpage_if_tab(self, tab_index):
-        if tab_index == 6 and not self.web_open:
+        if tab_index == 7 and not self.web_open:
             self.ui.webbrowser.load(QtCore.QUrl(self.dash_url))
             self.web_open = True
         elif self.web_open:

--- a/line_beam_parameters.py
+++ b/line_beam_parameters.py
@@ -208,7 +208,7 @@ class LineBeamParametersControl(Display):
 
         Parameters
         ----------
-        energy_range : int
+        bc_range : int
             The decimal value of the photon energy range.
         """
         if bc_range is None:
@@ -226,6 +226,7 @@ class LineBeamParametersControl(Display):
             self._bc_bits[key] = bool(status)
             cb = self.findChild(QtWidgets.QCheckBox, key)
             cb.setChecked(bool(status))
+        self.update_beamclass_max_from_bitmask(bc_range)
 
     def setup_bc_rbv_channel(self):
         prefix = self.config.get('line_arbiter_prefix')

--- a/line_beam_parameters.py
+++ b/line_beam_parameters.py
@@ -9,8 +9,7 @@ from qtpy import QtCore, QtWidgets
 
 from beamclass_table import bc_table, get_desc_for_bc, get_tooltip_for_bc
 from data_bounds import VALID_RATES, get_valid_rate
-from fast_faults import clear_channel
-from pmps import morph_into_vertical
+from utils import morph_into_vertical
 
 
 class LineBeamParametersControl(Display):
@@ -43,14 +42,12 @@ class LineBeamParametersControl(Display):
                                                         args=args,
                                                         macros=macros)
         self.config = macros
+        self._channels = []
         self.setup_ui()
 
-        if self.energy_channel is not None:
-            self.destroyed.connect(functools.partial(clear_channel,
-                                                     self.energy_channel))
-        if self.rate_channel is not None:
-            self.destroyed.connect(functools.partial(clear_channel,
-                                                     self.rate_channel))
+    def channels(self):
+        "Make sure PyDM can find the channels we set up for cleanup."
+        return self._channels
 
     def ui_filename(self):
         return 'line_beam_parameters.ui'
@@ -126,6 +123,7 @@ class LineBeamParametersControl(Display):
             value_signal=self.energy_range_signal
         )
         self.energy_channel.connect()
+        self._channels.append(self.energy_channel)
 
     def energy_range_changed(self, energy_range):
         """
@@ -173,6 +171,9 @@ class LineBeamParametersControl(Display):
             f'ca://{prefix}BeamParamCntl:ReqBP:BeamClass_RBV',
             value_slot=self.watch_beamclass_rbv_update,
         )
+        self._channels.append(self.rate_channel)
+        self._channels.append(self.beamclass_channel)
+        self._channels.append(self.beamclass_rbv_channel)
 
     def setup_zero_rate(self):
         self.ui.zeroRate.clicked.connect(self.set_zero_rate)

--- a/line_beam_parameters.py
+++ b/line_beam_parameters.py
@@ -402,7 +402,7 @@ class LineBeamParametersControl(Display):
         self.update_ev_tooltip()
 
     def on_bc_range_rbv_update(self, value):
-        # Update the rbv tooltip
+        # Update the rbv tooltips
         self.ui.bc_rbv_bytes.PyDMToolTip = get_tooltip_for_bc_bitmask(value)
         # Update the max bc label
         count = 0
@@ -410,4 +410,4 @@ class LineBeamParametersControl(Display):
             count += 1
             value = value >> 1
         self.ui.max_bc_label.setText(str(count))
-        self.ui.max_bc_label.setToolTip(get_tooltip_for_bc_bitmask(value))
+        self.ui.max_bc_label.setToolTip(get_tooltip_for_bc(count))

--- a/line_beam_parameters.py
+++ b/line_beam_parameters.py
@@ -6,9 +6,10 @@ from pydm.widgets import PyDMLabel
 from pydm.widgets.channel import PyDMChannel
 from qtpy import QtCore, QtWidgets
 
-from beamclass_table import (bc_table, get_desc_for_bc, get_tooltip_for_bc,
-                             install_bc_setText)
+from beamclass_table import bc_table, get_desc_for_bc, install_bc_setText
 from data_bounds import VALID_RATES, get_valid_rate
+from tooltips import (get_ev_range_tooltip, get_tooltip_for_bc,
+                      get_tooltip_for_bc_bitmask)
 from utils import morph_into_vertical
 
 
@@ -58,6 +59,7 @@ class LineBeamParametersControl(Display):
         self.setup_rate_channel()
         self.setup_bc_bits_connections()
         self.setup_bc_range_channel()
+        self.setup_ev_rbv_channel()
         self.setup_bc_rbv_channel()
         self.setup_zero_rate()
         self.setup_rate_combo()
@@ -159,6 +161,8 @@ class LineBeamParametersControl(Display):
 
         Connect all the check boxes bits with the calc_energy_range method to
         calculate the range upon changing a bit state.
+
+        Set a tooltip on each checkbox that makes it clear what that bit controls.
         """
         self.update_beamclass_signal.connect(self.update_beamclass_bitmask_from_max)
         self.bc_range_signal.connect(self.update_beamclass_max_from_bitmask)
@@ -166,6 +170,7 @@ class LineBeamParametersControl(Display):
             cb = self.findChild(QtWidgets.QCheckBox, key)
             cb.clicked.connect(functools.partial(
                 self.calc_bc_range, key))
+            cb.setToolTip(get_tooltip_for_bc(1 + int(key.split('_')[0][3:])))
 
     def calc_bc_range(self, key, checked):
         """
@@ -228,12 +233,29 @@ class LineBeamParametersControl(Display):
             cb.setChecked(bool(status))
         self.update_beamclass_max_from_bitmask(bc_range)
 
+    def setup_ev_rbv_channel(self):
+        prefix = self.config.get('line_arbiter_prefix')
+        self.ev_ranges = None
+        self.last_ev_range = 0
+        ev_definition = PyDMChannel(
+            f'ca://{prefix}eVRangeCnst_RBV',
+            value_slot=self.new_ev_ranges,
+        )
+        ev_definition.connect()
+        self._channels.append(ev_definition)
+        self.ev_range_rbv_channel = PyDMChannel(
+            f'ca://{prefix}BeamParamCntl:ReqBP:PhotonEnergyRanges_RBV',
+            value_slot=self.on_ev_range_rbv_update,
+        )
+        self.ev_range_rbv_channel.connect()
+        self._channels.append(self.ev_range_rbv_channel)
+
     def setup_bc_rbv_channel(self):
         prefix = self.config.get('line_arbiter_prefix')
         ch = f'ca://{prefix}BeamParamCntl:ReqBP:BeamClassRanges_RBV'
         self.bc_range_rbv_channel = PyDMChannel(
             ch,
-            value_slot=self.update_beamclass_max_rbv_from_bitmask,
+            value_slot=self.on_bc_range_rbv_update,
         )
         self.bc_range_rbv_channel.connect()
         self._channels.append(self.bc_range_rbv_channel)
@@ -363,9 +385,29 @@ class LineBeamParametersControl(Display):
             value = value >> 1
         self.update_beamclass_combobox_value(count)
 
-    def update_beamclass_max_rbv_from_bitmask(self, value):
+    def on_ev_range_rbv_update(self, value):
+        self.update_ev_tooltip(value)
+
+    def update_ev_tooltip(self, value=None):
+        if value is None:
+            value = self.last_ev_range
+        else:
+            self.last_ev_range = value
+        if self.ev_ranges is None:
+            return
+        self.ui.ev_rbv_bytes.PyDMToolTip = get_ev_range_tooltip(value, self.ev_ranges)
+
+    def new_ev_ranges(self, value):
+        self.ev_ranges = value
+        self.update_ev_tooltip()
+
+    def on_bc_range_rbv_update(self, value):
+        # Update the rbv tooltip
+        self.ui.bc_rbv_bytes.PyDMToolTip = get_tooltip_for_bc_bitmask(value)
+        # Update the max bc label
         count = 0
         while value > 0:
             count += 1
             value = value >> 1
-        self.max_bc_label.setText(str(count))
+        self.ui.max_bc_label.setText(str(count))
+        self.ui.max_bc_label.setToolTip(get_tooltip_for_bc_bitmask(value))

--- a/line_beam_parameters.py
+++ b/line_beam_parameters.py
@@ -7,7 +7,8 @@ from pydm.widgets import PyDMLabel
 from pydm.widgets.channel import PyDMChannel
 from qtpy import QtCore, QtWidgets
 
-from beamclass_table import bc_table, get_desc_for_bc, get_tooltip_for_bc
+from beamclass_table import (bc_table, get_desc_for_bc, get_tooltip_for_bc,
+                             install_bc_setText)
 from data_bounds import VALID_RATES, get_valid_rate
 from utils import morph_into_vertical
 
@@ -59,6 +60,7 @@ class LineBeamParametersControl(Display):
         self.setup_rate_channel()
         self.setup_zero_rate()
         self.setup_rate_combo()
+        install_bc_setText(self.ui.beamclass_rbv_label)
         self.setup_beamclass_combo()
         self.rate_channel.connect()
 

--- a/line_beam_parameters.py
+++ b/line_beam_parameters.py
@@ -63,6 +63,7 @@ class LineBeamParametersControl(Display):
         self.setup_rate_channel()
         self.setup_bc_bits_connections()
         self.setup_bc_range_channel()
+        self.setup_bc_rbv_channel()
         self.setup_zero_rate()
         self.setup_rate_combo()
         install_bc_setText(self.ui.max_bc_label)
@@ -258,7 +259,6 @@ class LineBeamParametersControl(Display):
     def setup_bc_rbv_channel(self):
         prefix = self.config.get('line_arbiter_prefix')
         ch = f'ca://{prefix}BeamParamCntl:ReqBP:BeamClassRanges_RBV'
-
         self.bc_range_rbv_channel = PyDMChannel(
             ch,
             value_slot=self.update_beamclass_max_rbv_from_bitmask,

--- a/line_beam_parameters.py
+++ b/line_beam_parameters.py
@@ -179,7 +179,7 @@ class LineBeamParametersControl(Display):
         """
         self.update_beamclass_signal.connect(self.update_beamclass_bitmask_from_max)
         self.bc_range_signal.connect(self.update_beamclass_max_from_bitmask)
-        for key in self._bits:
+        for key in self._bc_bits:
             cb = self.findChild(QtWidgets.QCheckBox, key)
             cb.stateChanged.connect(functools.partial(
                 self.calc_bc_range, key))
@@ -210,7 +210,7 @@ class LineBeamParametersControl(Display):
             map(int, [value for value in self._bc_bits.values()])
         )
 
-        if not self._setting_bits:
+        if not self._setting_bc_bits:
             # emit the decimal value to the PhotonEnergyRange
             self.bc_range_signal.emit(decimal_value)
 
@@ -370,7 +370,7 @@ class LineBeamParametersControl(Display):
         This does not write to the PV, it just changes the visual
         state of the combobox.
         """
-        self.ui.beamclassCombobox.setCurrentIndex(value)
+        self.ui.beamclassComboBox.setCurrentIndex(value)
 
     def update_beamclass_bitmask_from_max(self, value):
         """

--- a/line_beam_parameters.ui
+++ b/line_beam_parameters.ui
@@ -6,587 +6,16 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>877</width>
-    <height>344</height>
+    <width>896</width>
+    <height>390</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="1">
-    <widget class="PyDMLabel" name="PyDMLabel">
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission_RBV</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1" colspan="2">
-    <widget class="QFrame" name="energy_range_frame">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>26</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="layoutDirection">
-      <enum>Qt::LeftToRight</enum>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::Panel</enum>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <property name="leftMargin">
-       <number>6</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QCheckBox" name="bit31">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit30">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit29">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit28">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit27">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit26">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit25">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit24">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit23">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit22">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit21">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit20">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit19">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit18">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit17">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit16">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit15">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit14">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit13">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit12">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit11">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit10">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit9">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit8">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit7">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit6">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit5">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit4">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit3">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit2">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit1">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit0">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="11" column="1">
-    <widget class="QComboBox" name="beamclassComboBox">
-     <property name="maximumSize">
-      <size>
-       <width>200</width>
-       <height>16777215</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="0">
-    <widget class="QLabel" name="label_19">
+   <item row="7" column="0">
+    <widget class="QLabel" name="label_16">
      <property name="font">
       <font>
        <weight>75</weight>
@@ -594,34 +23,11 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       </font>
      </property>
      <property name="text">
-      <string>Beamclass Max Select [SC]:</string>
+      <string>Requested Rate [NC]:</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_12">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Requested Transmission :</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1">
-    <widget class="QComboBox" name="rateComboBox">
-     <property name="maximumSize">
-      <size>
-       <width>200</width>
-       <height>16777215</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1">
+   <item row="10" column="1">
     <widget class="QFrame" name="energy_range_frame_2">
      <property name="minimumSize">
       <size>
@@ -900,20 +306,43 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </layout>
     </widget>
    </item>
-   <item row="3" column="3">
-    <spacer name="horizontalSpacer">
+   <item row="0" column="1">
+    <widget class="PyDMLabel" name="PyDMLabel">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission_RBV</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0">
+    <widget class="QLabel" name="label_21">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Beamclass Range Select [SC]:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="1">
+    <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>40</width>
-       <height>20</height>
+       <width>20</width>
+       <height>40</height>
       </size>
      </property>
     </spacer>
    </item>
-   <item row="6" column="2" rowspan="7">
+   <item row="7" column="2" rowspan="8">
     <widget class="QPushButton" name="zeroRate">
      <property name="minimumSize">
       <size>
@@ -936,8 +365,232 @@ and Zero BC</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label_16">
+   <item row="1" column="1">
+    <widget class="PyDMLineEdit" name="transEdit">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>26</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="precision" stdset="0">
+      <number>2</number>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="precisionFromPV" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission</string>
+     </property>
+     <property name="displayFormat" stdset="0">
+      <enum>PyDMLineEdit::Exponential</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="3">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="1">
+    <widget class="QComboBox" name="beamclassComboBox">
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="1">
+    <widget class="QLabel" name="max_bc_label">
+     <property name="text">
+      <string>Loading...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_7">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="leftMargin">
+      <number>4</number>
+     </property>
+     <property name="rightMargin">
+      <number>4</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label_bit14_2">
+       <property name="text">
+        <string>15</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit13_2">
+       <property name="text">
+        <string>14</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit12_2">
+       <property name="text">
+        <string>13</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit11_2">
+       <property name="text">
+        <string>12</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit10_2">
+       <property name="text">
+        <string>11</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit9_2">
+       <property name="text">
+        <string>10</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit8_2">
+       <property name="text">
+        <string>9</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit7_2">
+       <property name="text">
+        <string>8</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit6_2">
+       <property name="text">
+        <string>7</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit5_2">
+       <property name="text">
+        <string>6</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit4_2">
+       <property name="text">
+        <string>5</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit3_2">
+       <property name="text">
+        <string>4</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit2_2">
+       <property name="text">
+        <string>3</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit1_2">
+       <property name="text">
+        <string>2</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit0_2">
+       <property name="text">
+        <string>1</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_13">
      <property name="font">
       <font>
        <weight>75</weight>
@@ -945,24 +598,24 @@ and Zero BC</string>
       </font>
      </property>
      <property name="text">
-      <string>Requested Rate:</string>
+      <string>Photon Energy Range Select:</string>
      </property>
     </widget>
    </item>
-   <item row="13" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_20">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
+     <property name="text">
+      <string>Beamclass Ranges [SC]:</string>
      </property>
-    </spacer>
+    </widget>
    </item>
-   <item row="4" column="1" colspan="2">
+   <item row="5" column="1" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout_6">
      <property name="spacing">
       <number>0</number>
@@ -2102,15 +1755,8 @@ and Zero BC</string>
      </item>
     </layout>
    </item>
-   <item row="2" column="0" colspan="3">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0">
-    <widget class="QLabel" name="label_18">
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_15">
      <property name="font">
       <font>
        <weight>75</weight>
@@ -2118,16 +1764,35 @@ and Zero BC</string>
       </font>
      </property>
      <property name="text">
-      <string>Requested Beamclass Max:</string>
+      <string>Rate Select [NC]:</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="0" colspan="3">
-    <widget class="Line" name="line_2">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_12">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Requested Transmission :</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="3">
+    <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-    </widget>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item row="1" column="0">
     <widget class="QLabel" name="label_11">
@@ -2138,12 +1803,12 @@ and Zero BC</string>
       </font>
      </property>
      <property name="text">
-      <string>Transmission:</string>
+      <string>Transmission Select:</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="label_15">
+   <item row="13" column="0">
+    <widget class="QLabel" name="label_19">
      <property name="font">
       <font>
        <weight>75</weight>
@@ -2151,24 +1816,21 @@ and Zero BC</string>
       </font>
      </property>
      <property name="text">
-      <string>Rate [NC]:</string>
+      <string>Beamclass Simple Select [SC]:</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="label_20">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Beamclass Ranges:</string>
+   <item row="8" column="1">
+    <widget class="QComboBox" name="rateComboBox">
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
      </property>
     </widget>
    </item>
-   <item row="4" column="3">
+   <item row="5" column="3">
     <spacer name="horizontalSpacer_2">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -2181,7 +1843,14 @@ and Zero BC</string>
      </property>
     </spacer>
    </item>
-   <item row="12" column="1">
+   <item row="6" column="0" colspan="3">
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="1">
     <widget class="PyDMPushButton" name="applyButton">
      <property name="enabled">
       <bool>false</bool>
@@ -2218,8 +1887,559 @@ and Zero BC</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_13">
+   <item row="4" column="1" colspan="2">
+    <widget class="QFrame" name="energy_range_frame">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>26</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="layoutDirection">
+      <enum>Qt::LeftToRight</enum>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Panel</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QCheckBox" name="bit31">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit30">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit29">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit28">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit27">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit26">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit25">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit24">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit23">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit22">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit21">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit20">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit19">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit18">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit17">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit16">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit15">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit14">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit13">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit12">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit11">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit10">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit9">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit8">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit7">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit6">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit5">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit4">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit3">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit1">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit0">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="12" column="0">
+    <widget class="QLabel" name="label_18">
      <property name="font">
       <font>
        <weight>75</weight>
@@ -2227,48 +2447,11 @@ and Zero BC</string>
       </font>
      </property>
      <property name="text">
-      <string>Photon Energy Ranges:</string>
+      <string>Requested Max [SC]:</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="PyDMLineEdit" name="transEdit">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>100</width>
-       <height>26</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>200</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="precision" stdset="0">
-      <number>2</number>
-     </property>
-     <property name="showUnits" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="precisionFromPV" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission</string>
-     </property>
-     <property name="displayFormat" stdset="0">
-      <enum>PyDMLineEdit::Exponential</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
+   <item row="7" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="PyDMLabel" name="PyDMLabel_3">
@@ -2301,18 +2484,8 @@ and Zero BC</string>
      </item>
     </layout>
    </item>
-   <item row="10" column="1">
-    <widget class="QLabel" name="max_bc_label">
-     <property name="text">
-      <string>Loading...</string>
-     </property>
-    </widget>
-   </item>
    <item row="9" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_7">
-     <property name="spacing">
-      <number>0</number>
-     </property>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
      <property name="leftMargin">
       <number>4</number>
      </property>
@@ -2320,152 +2493,154 @@ and Zero BC</string>
       <number>4</number>
      </property>
      <item>
-      <widget class="QLabel" name="label_bit14_2">
-       <property name="text">
-        <string>15</string>
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator">
+       <property name="toolTip">
+        <string/>
        </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit13_2">
-       <property name="text">
-        <string>14</string>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
        </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit12_2">
-       <property name="text">
-        <string>13</string>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:BeamClassRanges_RBV</string>
        </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
+       <property name="orientation" stdset="0">
+        <enum>Qt::Horizontal</enum>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit11_2">
-       <property name="text">
-        <string>12</string>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
        </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
+       <property name="bigEndian" stdset="0">
+        <bool>true</bool>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit10_2">
-       <property name="text">
-        <string>11</string>
+       <property name="circles" stdset="0">
+        <bool>false</bool>
        </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
+       <property name="numBits" stdset="0">
+        <number>15</number>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit9_2">
-       <property name="text">
-        <string>10</string>
+       <property name="shift" stdset="0">
+        <number>0</number>
        </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+         <string>Bit 1</string>
+         <string>Bit 2</string>
+         <string>Bit 3</string>
+         <string>Bit 4</string>
+         <string>Bit 5</string>
+         <string>Bit 6</string>
+         <string>Bit 7</string>
+         <string>Bit 8</string>
+         <string>Bit 9</string>
+         <string>Bit 10</string>
+         <string>Bit 11</string>
+         <string>Bit 12</string>
+         <string>Bit 13</string>
+         <string>Bit 14</string>
+        </stringlist>
        </property>
       </widget>
      </item>
+    </layout>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_14">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Photon Energy Ranges:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <property name="leftMargin">
+      <number>4</number>
+     </property>
+     <property name="rightMargin">
+      <number>4</number>
+     </property>
      <item>
-      <widget class="QLabel" name="label_bit8_2">
-       <property name="text">
-        <string>9</string>
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_2">
+       <property name="toolTip">
+        <string/>
        </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit7_2">
-       <property name="text">
-        <string>8</string>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
        </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit6_2">
-       <property name="text">
-        <string>7</string>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:PhotonEnergyRanges_RBV</string>
        </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
+       <property name="orientation" stdset="0">
+        <enum>Qt::Horizontal</enum>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit5_2">
-       <property name="text">
-        <string>6</string>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
        </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
+       <property name="bigEndian" stdset="0">
+        <bool>true</bool>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit4_2">
-       <property name="text">
-        <string>5</string>
+       <property name="circles" stdset="0">
+        <bool>false</bool>
        </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
+       <property name="numBits" stdset="0">
+        <number>32</number>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit3_2">
-       <property name="text">
-        <string>4</string>
+       <property name="shift" stdset="0">
+        <number>0</number>
        </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit2_2">
-       <property name="text">
-        <string>3</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit1_2">
-       <property name="text">
-        <string>2</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit0_2">
-       <property name="text">
-        <string>1</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+         <string>Bit 1</string>
+         <string>Bit 2</string>
+         <string>Bit 3</string>
+         <string>Bit 4</string>
+         <string>Bit 5</string>
+         <string>Bit 6</string>
+         <string>Bit 7</string>
+         <string>Bit 8</string>
+         <string>Bit 9</string>
+         <string>Bit 10</string>
+         <string>Bit 11</string>
+         <string>Bit 12</string>
+         <string>Bit 13</string>
+         <string>Bit 14</string>
+         <string>Bit 15</string>
+         <string>Bit 16</string>
+         <string>Bit 17</string>
+         <string>Bit 18</string>
+         <string>Bit 19</string>
+         <string>Bit 20</string>
+         <string>Bit 21</string>
+         <string>Bit 22</string>
+         <string>Bit 23</string>
+         <string>Bit 24</string>
+         <string>Bit 25</string>
+         <string>Bit 26</string>
+         <string>Bit 27</string>
+         <string>Bit 28</string>
+         <string>Bit 29</string>
+         <string>Bit 30</string>
+         <string>Bit 31</string>
+        </stringlist>
        </property>
       </widget>
      </item>
@@ -2478,6 +2653,11 @@ and Zero BC</string>
    <class>PyDMLabel</class>
    <extends>QLabel</extends>
    <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMByteIndicator</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.byte</header>
   </customwidget>
   <customwidget>
    <class>PyDMLineEdit</class>

--- a/line_beam_parameters.ui
+++ b/line_beam_parameters.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>4095</width>
-    <height>410</height>
+    <width>877</width>
+    <height>341</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -681,6 +681,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
        <property name="enabled">
         <bool>false</bool>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <family>Arial</family>
@@ -711,6 +717,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       <widget class="PyDMLabel" name="label_bit30">
        <property name="enabled">
         <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="font">
         <font>
@@ -743,6 +755,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
        <property name="enabled">
         <bool>false</bool>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <family>Arial</family>
@@ -773,6 +791,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       <widget class="PyDMLabel" name="label_bit28">
        <property name="enabled">
         <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="font">
         <font>
@@ -805,6 +829,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
        <property name="enabled">
         <bool>false</bool>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <family>Arial</family>
@@ -835,6 +865,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       <widget class="PyDMLabel" name="label_bit26">
        <property name="enabled">
         <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="font">
         <font>
@@ -867,6 +903,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
        <property name="enabled">
         <bool>false</bool>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <family>Arial</family>
@@ -897,6 +939,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       <widget class="PyDMLabel" name="label_bit24">
        <property name="enabled">
         <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="font">
         <font>
@@ -929,6 +977,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
        <property name="enabled">
         <bool>false</bool>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <family>Arial</family>
@@ -959,6 +1013,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       <widget class="PyDMLabel" name="label_bit22">
        <property name="enabled">
         <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="font">
         <font>
@@ -991,6 +1051,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
        <property name="enabled">
         <bool>false</bool>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <family>Arial</family>
@@ -1021,6 +1087,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       <widget class="PyDMLabel" name="label_bit20">
        <property name="enabled">
         <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="font">
         <font>
@@ -1053,6 +1125,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
        <property name="enabled">
         <bool>false</bool>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <family>Arial</family>
@@ -1083,6 +1161,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       <widget class="PyDMLabel" name="label_bit18">
        <property name="enabled">
         <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="font">
         <font>
@@ -1115,6 +1199,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
        <property name="enabled">
         <bool>false</bool>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <family>Arial</family>
@@ -1146,6 +1236,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
        <property name="enabled">
         <bool>false</bool>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <family>Arial</family>
@@ -1173,6 +1269,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       <widget class="PyDMLabel" name="label_bit15">
        <property name="enabled">
         <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="font">
         <font>
@@ -1202,6 +1304,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
        <property name="enabled">
         <bool>false</bool>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <family>Arial</family>
@@ -1229,6 +1337,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       <widget class="PyDMLabel" name="label_bit13">
        <property name="enabled">
         <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="font">
         <font>
@@ -1258,6 +1372,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
        <property name="enabled">
         <bool>false</bool>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <family>Arial</family>
@@ -1285,6 +1405,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       <widget class="PyDMLabel" name="label_bit11">
        <property name="enabled">
         <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="font">
         <font>
@@ -1314,6 +1440,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
        <property name="enabled">
         <bool>false</bool>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <family>Arial</family>
@@ -1341,6 +1473,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       <widget class="PyDMLabel" name="label_bit9">
        <property name="enabled">
         <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="font">
         <font>
@@ -1370,6 +1508,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
        <property name="enabled">
         <bool>false</bool>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <family>Arial</family>
@@ -1397,6 +1541,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       <widget class="PyDMLabel" name="label_bit7">
        <property name="enabled">
         <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="font">
         <font>
@@ -1426,6 +1576,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
        <property name="enabled">
         <bool>false</bool>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <family>Arial</family>
@@ -1453,6 +1609,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       <widget class="PyDMLabel" name="label_bit5">
        <property name="enabled">
         <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="font">
         <font>
@@ -1482,6 +1644,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
        <property name="enabled">
         <bool>false</bool>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <family>Arial</family>
@@ -1509,6 +1677,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       <widget class="PyDMLabel" name="label_bit3">
        <property name="enabled">
         <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="font">
         <font>
@@ -1538,6 +1712,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
        <property name="enabled">
         <bool>false</bool>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <family>Arial</family>
@@ -1566,6 +1746,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
        <property name="enabled">
         <bool>false</bool>
        </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <family>Arial</family>
@@ -1593,6 +1779,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       <widget class="PyDMLabel" name="label_bit0">
        <property name="enabled">
         <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>15</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="font">
         <font>

--- a/line_beam_parameters.ui
+++ b/line_beam_parameters.ui
@@ -2493,7 +2493,7 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       <number>4</number>
      </property>
      <item>
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator">
+      <widget class="PyDMByteIndicator" name="bc_rbv_bytes">
        <property name="toolTip">
         <string/>
        </property>
@@ -2572,7 +2572,7 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       <number>4</number>
      </property>
      <item>
-      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_2">
+      <widget class="PyDMByteIndicator" name="ev_rbv_bytes">
        <property name="toolTip">
         <string/>
        </property>

--- a/line_beam_parameters.ui
+++ b/line_beam_parameters.ui
@@ -7,26 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>877</width>
-    <height>341</height>
+    <height>342</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_12">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Requested Transmission :</string>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="1">
     <widget class="PyDMLabel" name="PyDMLabel">
      <property name="toolTip">
@@ -34,76 +21,6 @@
      </property>
      <property name="channel" stdset="0">
       <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission_RBV</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_11">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Transmission:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="PyDMLineEdit" name="transEdit">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>100</width>
-       <height>26</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>200</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="precision" stdset="0">
-      <number>2</number>
-     </property>
-     <property name="showUnits" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="precisionFromPV" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission</string>
-     </property>
-     <property name="displayFormat" stdset="0">
-      <enum>PyDMLineEdit::Exponential</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="3">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_13">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Photon Energy Ranges:</string>
      </property>
     </widget>
    </item>
@@ -658,6 +575,331 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </layout>
     </widget>
    </item>
+   <item row="11" column="1">
+    <widget class="QComboBox" name="beamclassComboBox">
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0">
+    <widget class="QLabel" name="label_19">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Beamclass Max Select [SC]:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_12">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Requested Transmission :</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QComboBox" name="rateComboBox">
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="QFrame" name="energy_range_frame_2">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>26</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="layoutDirection">
+      <enum>Qt::LeftToRight</enum>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Panel</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QCheckBox" name="bit14_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit13_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit12_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit11_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit10_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit9_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit8_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit7_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit6_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit5_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit4_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit3_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit2_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit1_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit0_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item row="3" column="3">
     <spacer name="horizontalSpacer">
      <property name="orientation">
@@ -667,6 +909,55 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       <size>
        <width>40</width>
        <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="6" column="2" rowspan="7">
+    <widget class="QPushButton" name="zeroRate">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>150</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>150</height>
+      </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">background-color: rgb(255, 85, 85);</string>
+     </property>
+     <property name="text">
+      <string>Zero Rate
+and Zero BC</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_16">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Requested Rate:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
       </size>
      </property>
     </spacer>
@@ -1811,18 +2102,25 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </item>
     </layout>
    </item>
-   <item row="4" column="3">
-    <spacer name="horizontalSpacer_2">
+   <item row="2" column="0" colspan="3">
+    <widget class="Line" name="line">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
+    </widget>
+   </item>
+   <item row="10" column="0">
+    <widget class="QLabel" name="label_18">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
      </property>
-    </spacer>
+     <property name="text">
+      <string>Requested Beamclass Max:</string>
+     </property>
+    </widget>
    </item>
    <item row="5" column="0" colspan="3">
     <widget class="Line" name="line_2">
@@ -1831,8 +2129,8 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label_16">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_11">
      <property name="font">
       <font>
        <weight>75</weight>
@@ -1840,62 +2138,7 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       </font>
      </property>
      <property name="text">
-      <string>Requested Rate:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="PyDMLabel" name="PyDMLabel_3">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Rate_RBV</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_17">
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>Hz</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="6" column="2" rowspan="5">
-    <widget class="QPushButton" name="zeroRate">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>150</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>150</height>
-      </size>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">background-color: rgb(255, 85, 85);</string>
-     </property>
-     <property name="text">
-      <string>Zero Rate</string>
+      <string>Transmission:</string>
      </property>
     </widget>
    </item>
@@ -1912,18 +2155,8 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
-    <widget class="QComboBox" name="rateComboBox">
-     <property name="maximumSize">
-      <size>
-       <width>200</width>
-       <height>16777215</height>
-      </size>
-     </property>
-    </widget>
-   </item>
    <item row="8" column="0">
-    <widget class="QLabel" name="label_18">
+    <widget class="QLabel" name="label_20">
      <property name="font">
       <font>
        <weight>75</weight>
@@ -1931,62 +2164,24 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       </font>
      </property>
      <property name="text">
-      <string>Requested Beamclass:</string>
+      <string>Beamclass Ranges:</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
-    <widget class="PyDMLabel" name="beamclass_rbv_label">
-     <property name="toolTip">
-      <string/>
+   <item row="4" column="3">
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <property name="precision" stdset="0">
-      <number>0</number>
-     </property>
-     <property name="showUnits" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="precisionFromPV" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="alarmSensitiveContent" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="alarmSensitiveBorder" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="PyDMToolTip" stdset="0">
-      <string/>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:BeamClass_RBV</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="label_19">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Beamclass [SC]:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1">
-    <widget class="QComboBox" name="beamclassComboBox">
-     <property name="maximumSize">
+     <property name="sizeHint" stdset="0">
       <size>
-       <width>200</width>
-       <height>16777215</height>
+       <width>40</width>
+       <height>20</height>
       </size>
      </property>
-    </widget>
+    </spacer>
    </item>
-   <item row="10" column="1">
+   <item row="12" column="1">
     <widget class="PyDMPushButton" name="applyButton">
      <property name="enabled">
       <bool>false</bool>
@@ -2023,18 +2218,702 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </property>
     </widget>
    </item>
-   <item row="11" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_13">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
      </property>
-     <property name="sizeHint" stdset="0">
+     <property name="text">
+      <string>Photon Energy Ranges:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="PyDMLineEdit" name="transEdit">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
       <size>
-       <width>20</width>
-       <height>40</height>
+       <width>100</width>
+       <height>26</height>
       </size>
      </property>
-    </spacer>
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="precision" stdset="0">
+      <number>2</number>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="precisionFromPV" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission</string>
+     </property>
+     <property name="displayFormat" stdset="0">
+      <enum>PyDMLineEdit::Exponential</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="PyDMLabel" name="PyDMLabel_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Rate_RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_17">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Hz</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="10" column="1">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Loading...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_7">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="PyDMLabel" name="label_bit14_2">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>15</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit13_2">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>14</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit12_2">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>13</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit11_2">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>12</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit10_2">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>11</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit9_2">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>10</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit8_2">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>9</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit7_2">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>8</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit6_2">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>7</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit5_2">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>6</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit4_2">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>5</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit3_2">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>4</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit2_2">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>3</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit1_2">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>2</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit0_2">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>1</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string/>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/line_beam_parameters.ui
+++ b/line_beam_parameters.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>877</width>
-    <height>342</height>
+    <height>344</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -2302,7 +2302,7 @@ and Zero BC</string>
     </layout>
    </item>
    <item row="10" column="1">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="max_bc_label">
      <property name="text">
       <string>Loading...</string>
      </property>
@@ -2313,603 +2313,159 @@ and Zero BC</string>
      <property name="spacing">
       <number>0</number>
      </property>
+     <property name="leftMargin">
+      <number>4</number>
+     </property>
+     <property name="rightMargin">
+      <number>4</number>
+     </property>
      <item>
-      <widget class="PyDMLabel" name="label_bit14_2">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
+      <widget class="QLabel" name="label_bit14_2">
        <property name="text">
         <string>15</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
        </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string/>
-       </property>
       </widget>
      </item>
      <item>
-      <widget class="PyDMLabel" name="label_bit13_2">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
+      <widget class="QLabel" name="label_bit13_2">
        <property name="text">
         <string>14</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
        </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string/>
-       </property>
       </widget>
      </item>
      <item>
-      <widget class="PyDMLabel" name="label_bit12_2">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
+      <widget class="QLabel" name="label_bit12_2">
        <property name="text">
         <string>13</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
        </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string/>
-       </property>
       </widget>
      </item>
      <item>
-      <widget class="PyDMLabel" name="label_bit11_2">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
+      <widget class="QLabel" name="label_bit11_2">
        <property name="text">
         <string>12</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
        </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string/>
-       </property>
       </widget>
      </item>
      <item>
-      <widget class="PyDMLabel" name="label_bit10_2">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
+      <widget class="QLabel" name="label_bit10_2">
        <property name="text">
         <string>11</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
        </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string/>
-       </property>
       </widget>
      </item>
      <item>
-      <widget class="PyDMLabel" name="label_bit9_2">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
+      <widget class="QLabel" name="label_bit9_2">
        <property name="text">
         <string>10</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
        </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string/>
-       </property>
       </widget>
      </item>
      <item>
-      <widget class="PyDMLabel" name="label_bit8_2">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
+      <widget class="QLabel" name="label_bit8_2">
        <property name="text">
         <string>9</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
        </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string/>
-       </property>
       </widget>
      </item>
      <item>
-      <widget class="PyDMLabel" name="label_bit7_2">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
+      <widget class="QLabel" name="label_bit7_2">
        <property name="text">
         <string>8</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
        </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string/>
-       </property>
       </widget>
      </item>
      <item>
-      <widget class="PyDMLabel" name="label_bit6_2">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
+      <widget class="QLabel" name="label_bit6_2">
        <property name="text">
         <string>7</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
        </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string/>
-       </property>
       </widget>
      </item>
      <item>
-      <widget class="PyDMLabel" name="label_bit5_2">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
+      <widget class="QLabel" name="label_bit5_2">
        <property name="text">
         <string>6</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
        </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string/>
-       </property>
       </widget>
      </item>
      <item>
-      <widget class="PyDMLabel" name="label_bit4_2">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
+      <widget class="QLabel" name="label_bit4_2">
        <property name="text">
         <string>5</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
        </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string/>
-       </property>
       </widget>
      </item>
      <item>
-      <widget class="PyDMLabel" name="label_bit3_2">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
+      <widget class="QLabel" name="label_bit3_2">
        <property name="text">
         <string>4</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
        </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string/>
-       </property>
       </widget>
      </item>
      <item>
-      <widget class="PyDMLabel" name="label_bit2_2">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
+      <widget class="QLabel" name="label_bit2_2">
        <property name="text">
         <string>3</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
        </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string/>
-       </property>
       </widget>
      </item>
      <item>
-      <widget class="PyDMLabel" name="label_bit1_2">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
+      <widget class="QLabel" name="label_bit1_2">
        <property name="text">
         <string>2</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
        </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string/>
-       </property>
       </widget>
      </item>
      <item>
-      <widget class="PyDMLabel" name="label_bit0_2">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
+      <widget class="QLabel" name="label_bit0_2">
        <property name="text">
         <string>1</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string/>
        </property>
       </widget>
      </item>

--- a/line_beam_parameters.ui
+++ b/line_beam_parameters.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1715</width>
-    <height>291</height>
+    <width>4095</width>
+    <height>410</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,15 +27,18 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0" colspan="6">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="0" column="1">
+    <widget class="PyDMLabel" name="PyDMLabel">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission_RBV</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="2">
-    <widget class="QLabel" name="label_17">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_11">
      <property name="font">
       <font>
        <weight>75</weight>
@@ -43,66 +46,9 @@
       </font>
      </property>
      <property name="text">
-      <string>Hz</string>
+      <string>Transmission:</string>
      </property>
     </widget>
-   </item>
-   <item row="8" column="2">
-    <widget class="QPushButton" name="zeroRate">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>52</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>52</height>
-      </size>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">background-color: rgb(255, 85, 85);</string>
-     </property>
-     <property name="text">
-      <string>Zero Rate</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="5" rowspan="3">
-    <widget class="QPushButton" name="placeholder">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>52</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>52</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>[placeholder]</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="6">
-    <spacer name="horizontalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item row="1" column="1">
     <widget class="PyDMLineEdit" name="transEdit">
@@ -141,1041 +87,14 @@
      </property>
     </widget>
    </item>
-   <item row="11" column="0" colspan="6">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="5" column="1" colspan="5">
-    <layout class="QHBoxLayout" name="horizontalLayout_6">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="PyDMLabel" name="label_bit31">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[31:31]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit30">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[30:30]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit29">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[29:29]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit28">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[28:28]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit27">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[27:27]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit26">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[26:26]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit25">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[25:25]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit24">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[24:24]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit23">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[23:23]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit22">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[22:22]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit21">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[21:21]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit20">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[20:20]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit19">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[19:19]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit18">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[18:18]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit17">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[17:17]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit16">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[16:16]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit15">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[15:15]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit14">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[14:14]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit13">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[13:13]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit12">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[12:12]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit11">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[11:11]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit10">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[10:10]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit9">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[9:9]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit8">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[8:8]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit7">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[7:7]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit6">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[6:6]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit5">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[5:5]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit4">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[4:4]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit3">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[3:3]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit2">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[2:2]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit1">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[1:1]</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="label_bit0">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <family>Arial</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>25000</string>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[0:0]</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="10" column="1">
-    <widget class="PyDMPushButton" name="applyButton">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>100</width>
-       <height>26</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>200</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">background-color: rgb(148, 255, 85);</string>
-     </property>
-     <property name="text">
-      <string>Apply</string>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Apply</string>
-     </property>
-     <property name="showConfirmDialog" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="pressValue" stdset="0">
-      <string>1</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1">
-    <widget class="PyDMLabel" name="PyDMLabel_3">
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Rate_RBV</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="6">
-    <spacer name="horizontalSpacer">
+   <item row="2" column="0" colspan="3">
+    <widget class="Line" name="line">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_11">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Transmission:</string>
-     </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="label_13">
      <property name="font">
       <font>
@@ -1188,53 +107,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="label_16">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Requested Rate:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="6">
-    <widget class="Line" name="line_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1">
-    <widget class="QComboBox" name="rateComboBox"/>
-   </item>
-   <item row="8" column="0" rowspan="2">
-    <widget class="QLabel" name="label_15">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Rate:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="PyDMLabel" name="PyDMLabel">
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission_RBV</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1" colspan="5">
+   <item row="3" column="1" colspan="2">
     <widget class="QFrame" name="energy_range_frame">
      <property name="minimumSize">
       <size>
@@ -1784,6 +657,1192 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       </item>
      </layout>
     </widget>
+   </item>
+   <item row="3" column="3">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="4" column="1" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout_6">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="PyDMLabel" name="label_bit31">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[31:31]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[31:31]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit30">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[30:30]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[30:30]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit29">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[29:29]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[29:29]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit28">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[28:28]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[28:28]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit27">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[27:27]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[27:27]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit26">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[26:26]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[26:26]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit25">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[25:25]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[25:25]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit24">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[24:24]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[24:24]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit23">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[23:23]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[23:23]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit22">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[22:22]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[22:22]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit21">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[21:21]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[21:21]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit20">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[20:20]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[20:20]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit19">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[19:19]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[19:19]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit18">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[18:18]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[18:18]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit17">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[17:17]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[17:17]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit16">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[16:16]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[16:16]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit15">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[15:15]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[15:15]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit14">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[14:14]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[14:14]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit13">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[13:13]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[13:13]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit12">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[12:12]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[12:12]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit11">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[11:11]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[11:11]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit10">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[10:10]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[10:10]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit9">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[9:9]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[9:9]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit8">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[8:8]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[8:8]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit7">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[7:7]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[7:7]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit6">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[6:6]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[6:6]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit5">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[5:5]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[5:5]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit4">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[4:4]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[4:4]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit3">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[3:3]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[3:3]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit2">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[2:2]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[2:2]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit1">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[1:1]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[1:1]</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="label_bit0">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <family>Arial</family>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[0:0]</string>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}eVRangeCnst_RBV.[0:0]</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="4" column="3">
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="5" column="0" colspan="3">
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_16">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Requested Rate:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="PyDMLabel" name="PyDMLabel_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Rate_RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_17">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Hz</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="6" column="2" rowspan="5">
+    <widget class="QPushButton" name="zeroRate">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>150</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>150</height>
+      </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">background-color: rgb(255, 85, 85);</string>
+     </property>
+     <property name="text">
+      <string>Zero Rate</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label_15">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Rate [NC]:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QComboBox" name="rateComboBox">
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_18">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Requested Beamclass:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="PyDMLabel" name="beamclass_rbv_label">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="precision" stdset="0">
+      <number>0</number>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="precisionFromPV" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="PyDMToolTip" stdset="0">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:BeamClass_RBV</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_19">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Beamclass [SC]:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="QComboBox" name="beamclassComboBox">
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1">
+    <widget class="PyDMPushButton" name="applyButton">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>26</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">background-color: rgb(148, 255, 85);</string>
+     </property>
+     <property name="text">
+      <string>Apply</string>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Apply</string>
+     </property>
+     <property name="showConfirmDialog" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="pressValue" stdset="0">
+      <string>1</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/line_beam_parameters.ui
+++ b/line_beam_parameters.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>896</width>
-    <height>390</height>
+    <height>416</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -2484,72 +2484,6 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </item>
     </layout>
    </item>
-   <item row="9" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <property name="leftMargin">
-      <number>4</number>
-     </property>
-     <property name="rightMargin">
-      <number>4</number>
-     </property>
-     <item>
-      <widget class="PyDMByteIndicator" name="bc_rbv_bytes">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:BeamClassRanges_RBV</string>
-       </property>
-       <property name="orientation" stdset="0">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="bigEndian" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="numBits" stdset="0">
-        <number>15</number>
-       </property>
-       <property name="shift" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="labels" stdset="0">
-        <stringlist>
-         <string>Bit 0</string>
-         <string>Bit 1</string>
-         <string>Bit 2</string>
-         <string>Bit 3</string>
-         <string>Bit 4</string>
-         <string>Bit 5</string>
-         <string>Bit 6</string>
-         <string>Bit 7</string>
-         <string>Bit 8</string>
-         <string>Bit 9</string>
-         <string>Bit 10</string>
-         <string>Bit 11</string>
-         <string>Bit 12</string>
-         <string>Bit 13</string>
-         <string>Bit 14</string>
-        </stringlist>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
    <item row="3" column="0">
     <widget class="QLabel" name="label_14">
      <property name="font">
@@ -2563,88 +2497,200 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </property>
     </widget>
    </item>
+   <item row="9" column="1">
+    <widget class="QFrame" name="frame">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Panel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_8">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
+      <item>
+       <widget class="PyDMByteIndicator" name="bc_rbv_bytes">
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="alarmSensitiveContent" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="alarmSensitiveBorder" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="PyDMToolTip" stdset="0">
+         <string/>
+        </property>
+        <property name="channel" stdset="0">
+         <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:BeamClassRanges_RBV</string>
+        </property>
+        <property name="orientation" stdset="0">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="showLabels" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="bigEndian" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="circles" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="numBits" stdset="0">
+         <number>15</number>
+        </property>
+        <property name="shift" stdset="0">
+         <number>0</number>
+        </property>
+        <property name="labels" stdset="0">
+         <stringlist>
+          <string>Bit 0</string>
+          <string>Bit 1</string>
+          <string>Bit 2</string>
+          <string>Bit 3</string>
+          <string>Bit 4</string>
+          <string>Bit 5</string>
+          <string>Bit 6</string>
+          <string>Bit 7</string>
+          <string>Bit 8</string>
+          <string>Bit 9</string>
+          <string>Bit 10</string>
+          <string>Bit 11</string>
+          <string>Bit 12</string>
+          <string>Bit 13</string>
+          <string>Bit 14</string>
+         </stringlist>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item row="3" column="1" colspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout_5">
-     <property name="leftMargin">
-      <number>4</number>
+    <widget class="QFrame" name="frame_2">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>30</height>
+      </size>
      </property>
-     <property name="rightMargin">
-      <number>4</number>
+     <property name="frameShape">
+      <enum>QFrame::Panel</enum>
      </property>
-     <item>
-      <widget class="PyDMByteIndicator" name="ev_rbv_bytes">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:PhotonEnergyRanges_RBV</string>
-       </property>
-       <property name="orientation" stdset="0">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="bigEndian" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="numBits" stdset="0">
-        <number>32</number>
-       </property>
-       <property name="shift" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="labels" stdset="0">
-        <stringlist>
-         <string>Bit 0</string>
-         <string>Bit 1</string>
-         <string>Bit 2</string>
-         <string>Bit 3</string>
-         <string>Bit 4</string>
-         <string>Bit 5</string>
-         <string>Bit 6</string>
-         <string>Bit 7</string>
-         <string>Bit 8</string>
-         <string>Bit 9</string>
-         <string>Bit 10</string>
-         <string>Bit 11</string>
-         <string>Bit 12</string>
-         <string>Bit 13</string>
-         <string>Bit 14</string>
-         <string>Bit 15</string>
-         <string>Bit 16</string>
-         <string>Bit 17</string>
-         <string>Bit 18</string>
-         <string>Bit 19</string>
-         <string>Bit 20</string>
-         <string>Bit 21</string>
-         <string>Bit 22</string>
-         <string>Bit 23</string>
-         <string>Bit 24</string>
-         <string>Bit 25</string>
-         <string>Bit 26</string>
-         <string>Bit 27</string>
-         <string>Bit 28</string>
-         <string>Bit 29</string>
-         <string>Bit 30</string>
-         <string>Bit 31</string>
-        </stringlist>
-       </property>
-      </widget>
-     </item>
-    </layout>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
+      <item>
+       <widget class="PyDMByteIndicator" name="ev_rbv_bytes">
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="alarmSensitiveContent" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="alarmSensitiveBorder" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="PyDMToolTip" stdset="0">
+         <string/>
+        </property>
+        <property name="channel" stdset="0">
+         <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:PhotonEnergyRanges_RBV</string>
+        </property>
+        <property name="orientation" stdset="0">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="showLabels" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="bigEndian" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="circles" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="numBits" stdset="0">
+         <number>32</number>
+        </property>
+        <property name="shift" stdset="0">
+         <number>0</number>
+        </property>
+        <property name="labels" stdset="0">
+         <stringlist>
+          <string>Bit 0</string>
+          <string>Bit 1</string>
+          <string>Bit 2</string>
+          <string>Bit 3</string>
+          <string>Bit 4</string>
+          <string>Bit 5</string>
+          <string>Bit 6</string>
+          <string>Bit 7</string>
+          <string>Bit 8</string>
+          <string>Bit 9</string>
+          <string>Bit 10</string>
+          <string>Bit 11</string>
+          <string>Bit 12</string>
+          <string>Bit 13</string>
+          <string>Bit 14</string>
+          <string>Bit 15</string>
+          <string>Bit 16</string>
+          <string>Bit 17</string>
+          <string>Bit 18</string>
+          <string>Bit 19</string>
+          <string>Bit 20</string>
+          <string>Bit 21</string>
+          <string>Bit 22</string>
+          <string>Bit 23</string>
+          <string>Bit 24</string>
+          <string>Bit 25</string>
+          <string>Bit 26</string>
+          <string>Bit 27</string>
+          <string>Bit 28</string>
+          <string>Bit 29</string>
+          <string>Bit 30</string>
+          <string>Bit 31</string>
+         </stringlist>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/pmps.py
+++ b/pmps.py
@@ -8,7 +8,7 @@ from pydm import Display
 from pydm.widgets import PyDMByteIndicator, PyDMLabel
 from pydm.widgets.channel import PyDMChannel
 
-from beamclass_table import get_tooltip_for_bc
+from beamclass_table import get_tooltip_for_bc, install_bc_setText
 from utils import morph_into_vertical
 
 logger = logging.getLogger(__name__)
@@ -83,6 +83,7 @@ class PMPS(Display):
             )
             ch.connect()
             self._channels.append(ch)
+            install_bc_setText(label)
 
     def update_bc_tooltip(self, value, label):
         label.PyDMToolTip = get_tooltip_for_bc(value)

--- a/pmps.py
+++ b/pmps.py
@@ -109,10 +109,11 @@ class PMPS(Display):
         self.setup_ev_calculation()
         self.setup_line_parameters_control()
         self.setup_plc_ioc_status()
+        self.setup_beam_class_table()
 
         dash_url = self.config.get('dashboard_url')
         if self.user_args.no_web or dash_url is None:
-            self.ui.tab_arbiter_outputs.removeTab(6)
+            self.ui.tab_arbiter_outputs.removeTab(7)
         else:
             self.setup_grafana_log_display()
 
@@ -158,6 +159,12 @@ class PMPS(Display):
         plc_widget = PLCIOCStatus(macros=self.config)
         tab.layout().addWidget(plc_widget)
 
+    def setup_beam_class_table(self):
+        from beamclass_table import BeamclassTable
+        tab = self.ui.tb_beamclass_table
+        beamclass_widget = BeamclassTable(macros=self.config)
+        tab.layout().addWidget(beamclass_widget)
+
     def setup_grafana_log_display(self):
         from grafana_log_display import GrafanaLogDisplay
         tab = self.ui.tb_grafana_log_display
@@ -166,7 +173,6 @@ class PMPS(Display):
             grafana_widget.open_webpage_if_tab,
         )
         tab.layout().addWidget(grafana_widget)
-
 
     def ui_filename(self):
         return 'pmps.ui'

--- a/pmps.py
+++ b/pmps.py
@@ -68,7 +68,11 @@ class PMPS(Display):
         with open(c_file, 'r') as f:
             config = yaml.safe_load(f)
 
-        macros_from_config = ['line_arbiter_prefix', 'undulator_kicker_rate_pv']
+        macros_from_config = [
+            'line_arbiter_prefix',
+            'undulator_kicker_rate_pv',
+            'accelerator_mode_pv',
+        ]
 
         for m in macros_from_config:
             if m in macros:
@@ -103,7 +107,7 @@ class PMPS(Display):
         self.setup_preemptive_requests()
         self.setup_arbiter_outputs()
         self.setup_ev_calculation()
-        self.setup_line_parameters_contorl()
+        self.setup_line_parameters_control()
         self.setup_plc_ioc_status()
 
         dash_url = self.config.get('dashboard_url')
@@ -142,7 +146,7 @@ class PMPS(Display):
         ev_widget = EVCalculation(macros=self.config)
         tab.layout().addWidget(ev_widget)
 
-    def setup_line_parameters_contorl(self):
+    def setup_line_parameters_control(self):
         from line_beam_parameters import LineBeamParametersControl
         tab = self.ui.tb_line_beam_param_ctrl
         beam_widget = LineBeamParametersControl(macros=self.config)

--- a/pmps.ui
+++ b/pmps.ui
@@ -159,7 +159,7 @@
         <item>
          <layout class="QGridLayout" name="gridLayout_2">
           <item row="3" column="1">
-           <widget class="PyDMLabel" name="PyDMLabel_5">
+           <widget class="PyDMLabel" name="curr_bc_label">
             <property name="enabled">
              <bool>false</bool>
             </property>
@@ -352,7 +352,7 @@
            </widget>
           </item>
           <item row="3" column="2">
-           <widget class="PyDMLabel" name="PyDMLabel_40">
+           <widget class="PyDMLabel" name="req_bc_label">
             <property name="enabled">
              <bool>false</bool>
             </property>

--- a/pmps.ui
+++ b/pmps.ui
@@ -1595,6 +1595,12 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_7"/>
      </widget>
+     <widget class="QWidget" name="tb_beamclass_table">
+      <attribute name="title">
+       <string>Beamclass Table</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_11"/>
+     </widget>
      <widget class="QWidget" name="tb_grafana_log_display">
       <attribute name="title">
        <string>Grafana Log Display</string>

--- a/pmps.ui
+++ b/pmps.ui
@@ -170,7 +170,7 @@
              <string>ca://${line_arbiter_prefix}CurrentBP:BeamClass_RBV</string>
             </property>
             <property name="rules" stdset="0">
-             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]==\&quot;SC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
+             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]!=\&quot;NC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
             </property>
             <property name="precision" stdset="0">
              <number>0</number>
@@ -248,7 +248,7 @@
              <string/>
             </property>
             <property name="rules" stdset="0">
-             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]==\&quot;NC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
+             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]!=\&quot;SC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
             </property>
             <property name="precision" stdset="0">
              <number>0</number>
@@ -326,7 +326,7 @@
              <string/>
             </property>
             <property name="rules" stdset="0">
-             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]==\&quot;NC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
+             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]!=\&quot;SC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
             </property>
             <property name="precision" stdset="0">
              <number>0</number>
@@ -363,7 +363,7 @@
              <string>ca://${line_arbiter_prefix}RequestedBP:BeamClass_RBV</string>
             </property>
             <property name="rules" stdset="0">
-             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]==\&quot;SC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
+             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]!=\&quot;NC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
             </property>
             <property name="precision" stdset="0">
              <number>0</number>
@@ -422,7 +422,7 @@
              <string>NC Rate</string>
             </property>
             <property name="rules" stdset="0">
-             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]==\&quot;NC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
+             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]!=\&quot;SC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
             </property>
             <property name="precision" stdset="0">
              <number>0</number>
@@ -462,7 +462,7 @@
              <string>SC Beam Class</string>
             </property>
             <property name="rules" stdset="0">
-             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]==\&quot;SC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
+             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]!=\&quot;NC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
             </property>
             <property name="precision" stdset="0">
              <number>0</number>

--- a/pmps.ui
+++ b/pmps.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>4095</width>
+    <width>1200</width>
     <height>742</height>
    </rect>
   </property>
@@ -166,6 +166,12 @@
             <property name="enabled">
              <bool>false</bool>
             </property>
+            <property name="maximumSize">
+             <size>
+              <width>200</width>
+              <height>16777215</height>
+             </size>
+            </property>
             <property name="toolTip">
              <string/>
             </property>
@@ -202,6 +208,12 @@
            <widget class="PyDMLabel" name="PyDMLabel_6">
             <property name="enabled">
              <bool>false</bool>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>200</width>
+              <height>16777215</height>
+             </size>
             </property>
             <property name="toolTip">
              <string/>
@@ -247,6 +259,12 @@
             <property name="enabled">
              <bool>false</bool>
             </property>
+            <property name="maximumSize">
+             <size>
+              <width>200</width>
+              <height>16777215</height>
+             </size>
+            </property>
             <property name="toolTip">
              <string/>
             </property>
@@ -280,6 +298,12 @@
            <widget class="PyDMLabel" name="PyDMLabel_3">
             <property name="enabled">
              <bool>false</bool>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>200</width>
+              <height>16777215</height>
+             </size>
             </property>
             <property name="toolTip">
              <string/>
@@ -325,6 +349,12 @@
             <property name="enabled">
              <bool>false</bool>
             </property>
+            <property name="maximumSize">
+             <size>
+              <width>200</width>
+              <height>16777215</height>
+             </size>
+            </property>
             <property name="toolTip">
              <string/>
             </property>
@@ -358,6 +388,12 @@
            <widget class="PyDMLabel" name="req_bc_label">
             <property name="enabled">
              <bool>false</bool>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>200</width>
+              <height>16777215</height>
+             </size>
             </property>
             <property name="toolTip">
              <string/>
@@ -610,6 +646,12 @@
               <property name="enabled">
                <bool>false</bool>
               </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
+              </property>
               <property name="font">
                <font>
                 <family>Arial</family>
@@ -634,6 +676,12 @@
              <widget class="PyDMLabel" name="PyDMLabel_38">
               <property name="enabled">
                <bool>false</bool>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
               </property>
               <property name="font">
                <font>
@@ -660,6 +708,12 @@
               <property name="enabled">
                <bool>false</bool>
               </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
+              </property>
               <property name="font">
                <font>
                 <family>Arial</family>
@@ -684,6 +738,12 @@
              <widget class="PyDMLabel" name="PyDMLabel_36">
               <property name="enabled">
                <bool>false</bool>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
               </property>
               <property name="font">
                <font>
@@ -710,6 +770,12 @@
               <property name="enabled">
                <bool>false</bool>
               </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
+              </property>
               <property name="font">
                <font>
                 <family>Arial</family>
@@ -734,6 +800,12 @@
              <widget class="PyDMLabel" name="PyDMLabel_34">
               <property name="enabled">
                <bool>false</bool>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
               </property>
               <property name="font">
                <font>
@@ -760,6 +832,12 @@
               <property name="enabled">
                <bool>false</bool>
               </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
+              </property>
               <property name="font">
                <font>
                 <family>Arial</family>
@@ -784,6 +862,12 @@
              <widget class="PyDMLabel" name="PyDMLabel_32">
               <property name="enabled">
                <bool>false</bool>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
               </property>
               <property name="font">
                <font>
@@ -810,6 +894,12 @@
               <property name="enabled">
                <bool>false</bool>
               </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
+              </property>
               <property name="font">
                <font>
                 <family>Arial</family>
@@ -834,6 +924,12 @@
              <widget class="PyDMLabel" name="PyDMLabel_30">
               <property name="enabled">
                <bool>false</bool>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
               </property>
               <property name="font">
                <font>
@@ -860,6 +956,12 @@
               <property name="enabled">
                <bool>false</bool>
               </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
+              </property>
               <property name="font">
                <font>
                 <family>Arial</family>
@@ -884,6 +986,12 @@
              <widget class="PyDMLabel" name="PyDMLabel_28">
               <property name="enabled">
                <bool>false</bool>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
               </property>
               <property name="font">
                <font>
@@ -910,6 +1018,12 @@
               <property name="enabled">
                <bool>false</bool>
               </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
+              </property>
               <property name="font">
                <font>
                 <family>Arial</family>
@@ -934,6 +1048,12 @@
              <widget class="PyDMLabel" name="PyDMLabel_26">
               <property name="enabled">
                <bool>false</bool>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
               </property>
               <property name="font">
                <font>
@@ -960,6 +1080,12 @@
               <property name="enabled">
                <bool>false</bool>
               </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
+              </property>
               <property name="font">
                <font>
                 <family>Arial</family>
@@ -984,6 +1110,12 @@
              <widget class="PyDMLabel" name="PyDMLabel_24">
               <property name="enabled">
                <bool>false</bool>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
               </property>
               <property name="font">
                <font>
@@ -1010,6 +1142,12 @@
               <property name="enabled">
                <bool>false</bool>
               </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
+              </property>
               <property name="font">
                <font>
                 <family>Arial</family>
@@ -1034,6 +1172,12 @@
              <widget class="PyDMLabel" name="PyDMLabel_11">
               <property name="enabled">
                <bool>false</bool>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
               </property>
               <property name="font">
                <font>
@@ -1060,6 +1204,12 @@
               <property name="enabled">
                <bool>false</bool>
               </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
+              </property>
               <property name="font">
                <font>
                 <family>Arial</family>
@@ -1084,6 +1234,12 @@
              <widget class="PyDMLabel" name="PyDMLabel_9">
               <property name="enabled">
                <bool>false</bool>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
               </property>
               <property name="font">
                <font>
@@ -1110,6 +1266,12 @@
               <property name="enabled">
                <bool>false</bool>
               </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
+              </property>
               <property name="font">
                <font>
                 <family>Arial</family>
@@ -1134,6 +1296,12 @@
              <widget class="PyDMLabel" name="PyDMLabel_13">
               <property name="enabled">
                <bool>false</bool>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
               </property>
               <property name="font">
                <font>
@@ -1160,6 +1328,12 @@
               <property name="enabled">
                <bool>false</bool>
               </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
+              </property>
               <property name="font">
                <font>
                 <family>Arial</family>
@@ -1184,6 +1358,12 @@
              <widget class="PyDMLabel" name="PyDMLabel_15">
               <property name="enabled">
                <bool>false</bool>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
               </property>
               <property name="font">
                <font>
@@ -1210,6 +1390,12 @@
               <property name="enabled">
                <bool>false</bool>
               </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
+              </property>
               <property name="font">
                <font>
                 <family>Arial</family>
@@ -1234,6 +1420,12 @@
              <widget class="PyDMLabel" name="PyDMLabel_16">
               <property name="enabled">
                <bool>false</bool>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
               </property>
               <property name="font">
                <font>
@@ -1260,6 +1452,12 @@
               <property name="enabled">
                <bool>false</bool>
               </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
+              </property>
               <property name="font">
                <font>
                 <family>Arial</family>
@@ -1284,6 +1482,12 @@
              <widget class="PyDMLabel" name="PyDMLabel_21">
               <property name="enabled">
                <bool>false</bool>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
               </property>
               <property name="font">
                <font>
@@ -1310,6 +1514,12 @@
               <property name="enabled">
                <bool>false</bool>
               </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
+              </property>
               <property name="font">
                <font>
                 <family>Arial</family>
@@ -1334,6 +1544,12 @@
              <widget class="PyDMLabel" name="PyDMLabel_18">
               <property name="enabled">
                <bool>false</bool>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
               </property>
               <property name="font">
                <font>
@@ -1360,6 +1576,12 @@
               <property name="enabled">
                <bool>false</bool>
               </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
+              </property>
               <property name="font">
                <font>
                 <family>Arial</family>
@@ -1384,6 +1606,12 @@
              <widget class="PyDMLabel" name="PyDMLabel_22">
               <property name="enabled">
                <bool>false</bool>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>16777215</height>
+               </size>
               </property>
               <property name="font">
                <font>

--- a/pmps.ui
+++ b/pmps.ui
@@ -87,6 +87,9 @@
       </widget>
      </item>
      <item>
+      <widget class="QComboBox" name="mode_combo"/>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="enabled">
         <bool>true</bool>
@@ -170,7 +173,7 @@
              <string>ca://${line_arbiter_prefix}CurrentBP:BeamClass_RBV</string>
             </property>
             <property name="rules" stdset="0">
-             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]!=\&quot;NC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
+             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]!=\&quot;NC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;loc://selected_mode&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
             </property>
             <property name="precision" stdset="0">
              <number>0</number>
@@ -248,7 +251,7 @@
              <string/>
             </property>
             <property name="rules" stdset="0">
-             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]!=\&quot;SC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
+             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]!=\&quot;SC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;loc://selected_mode&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
             </property>
             <property name="precision" stdset="0">
              <number>0</number>
@@ -326,7 +329,7 @@
              <string/>
             </property>
             <property name="rules" stdset="0">
-             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]!=\&quot;SC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
+             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]!=\&quot;SC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;loc://selected_mode&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
             </property>
             <property name="precision" stdset="0">
              <number>0</number>
@@ -363,7 +366,7 @@
              <string>ca://${line_arbiter_prefix}RequestedBP:BeamClass_RBV</string>
             </property>
             <property name="rules" stdset="0">
-             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]!=\&quot;NC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
+             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]!=\&quot;NC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;loc://selected_mode&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
             </property>
             <property name="precision" stdset="0">
              <number>0</number>
@@ -422,7 +425,7 @@
              <string>NC Rate</string>
             </property>
             <property name="rules" stdset="0">
-             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]!=\&quot;SC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
+             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]!=\&quot;SC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;loc://selected_mode&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
             </property>
             <property name="precision" stdset="0">
              <number>0</number>
@@ -462,7 +465,7 @@
              <string>SC Beam Class</string>
             </property>
             <property name="rules" stdset="0">
-             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]!=\&quot;NC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
+             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]!=\&quot;NC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;loc://selected_mode&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
             </property>
             <property name="precision" stdset="0">
              <number>0</number>

--- a/pmps.ui
+++ b/pmps.ui
@@ -1636,7 +1636,7 @@
            </layout>
           </item>
           <item row="2" column="1" colspan="2">
-           <widget class="PyDMByteIndicator" name="PyDMByteIndicator_3">
+           <widget class="PyDMByteIndicator" name="ev_req_bytes">
             <property name="enabled">
              <bool>false</bool>
             </property>

--- a/pmps.ui
+++ b/pmps.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1767</width>
+    <width>4095</width>
     <height>742</height>
    </rect>
   </property>
@@ -48,6 +48,41 @@
        </property>
        <property name="text">
         <string>${CFG}</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_5">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Mode:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="PyDMLabel_2">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QLabel {color: rgb(0, 0, 153);}</string>
+       </property>
+       <property name="text">
+        <string>ca://${accelerator_mode_pv}</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${accelerator_mode_pv}</string>
        </property>
       </widget>
      </item>
@@ -123,90 +158,44 @@
        <layout class="QVBoxLayout" name="verticalLayout">
         <item>
          <layout class="QGridLayout" name="gridLayout_2">
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_6">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="font">
-             <font>
-              <weight>75</weight>
-              <bold>true</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>Rate</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0" colspan="3">
-           <widget class="QLabel" name="label_2">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="font">
-             <font>
-              <weight>75</weight>
-              <bold>true</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>Beam Parameter Status</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="PyDMLabel" name="PyDMLabel">
+          <item row="3" column="1">
+           <widget class="PyDMLabel" name="PyDMLabel_5">
             <property name="enabled">
              <bool>false</bool>
             </property>
             <property name="toolTip">
              <string/>
             </property>
+            <property name="text">
+             <string>ca://${line_arbiter_prefix}CurrentBP:BeamClass_RBV</string>
+            </property>
+            <property name="rules" stdset="0">
+             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]==\&quot;SC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
+            </property>
+            <property name="precision" stdset="0">
+             <number>0</number>
+            </property>
             <property name="showUnits" stdset="0">
              <bool>true</bool>
             </property>
-            <property name="channel" stdset="0">
-             <string>ca://${line_arbiter_prefix}CurrentBP:Rate_RBV</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_7">
-            <property name="enabled">
+            <property name="precisionFromPV" stdset="0">
              <bool>true</bool>
             </property>
-            <property name="font">
-             <font>
-              <weight>75</weight>
-              <bold>true</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>Transmission</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <widget class="PyDMLabel" name="PyDMLabel_4">
-            <property name="enabled">
+            <property name="alarmSensitiveContent" stdset="0">
              <bool>false</bool>
             </property>
-            <property name="toolTip">
-             <string/>
-            </property>
-            <property name="showUnits" stdset="0">
+            <property name="alarmSensitiveBorder" stdset="0">
              <bool>true</bool>
             </property>
+            <property name="PyDMToolTip" stdset="0">
+             <string/>
+            </property>
             <property name="channel" stdset="0">
-             <string>ca://${line_arbiter_prefix}RequestedBP:Rate_RBV</string>
+             <string>ca://${line_arbiter_prefix}CurrentBP:BeamClass_RBV</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="2">
+          <item row="4" column="2">
            <widget class="PyDMLabel" name="PyDMLabel_6">
             <property name="enabled">
              <bool>false</bool>
@@ -250,26 +239,41 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="2">
-           <widget class="QLabel" name="label_4">
+          <item row="2" column="1">
+           <widget class="PyDMLabel" name="PyDMLabel">
             <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="rules" stdset="0">
+             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]==\&quot;NC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
+            </property>
+            <property name="precision" stdset="0">
+             <number>0</number>
+            </property>
+            <property name="showUnits" stdset="0">
              <bool>true</bool>
             </property>
-            <property name="font">
-             <font>
-              <weight>75</weight>
-              <bold>true</bold>
-             </font>
+            <property name="precisionFromPV" stdset="0">
+             <bool>true</bool>
             </property>
-            <property name="text">
-             <string>Requested</string>
+            <property name="alarmSensitiveContent" stdset="0">
+             <bool>false</bool>
             </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
+            <property name="alarmSensitiveBorder" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="PyDMToolTip" stdset="0">
+             <string/>
+            </property>
+            <property name="channel" stdset="0">
+             <string>ca://${line_arbiter_prefix}CurrentBP:Rate_RBV</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="4" column="1">
            <widget class="PyDMLabel" name="PyDMLabel_3">
             <property name="enabled">
              <bool>false</bool>
@@ -291,6 +295,211 @@
             </property>
             <property name="displayFormat" stdset="0">
              <enum>PyDMLabel::Exponential</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0" colspan="3">
+           <widget class="QLabel" name="label_2">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Beam Parameter Status</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="PyDMLabel" name="PyDMLabel_4">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="rules" stdset="0">
+             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]==\&quot;NC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
+            </property>
+            <property name="precision" stdset="0">
+             <number>0</number>
+            </property>
+            <property name="showUnits" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="precisionFromPV" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="alarmSensitiveContent" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="alarmSensitiveBorder" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="PyDMToolTip" stdset="0">
+             <string/>
+            </property>
+            <property name="channel" stdset="0">
+             <string>ca://${line_arbiter_prefix}RequestedBP:Rate_RBV</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="PyDMLabel" name="PyDMLabel_40">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="text">
+             <string>ca://${line_arbiter_prefix}RequestedBP:BeamClass_RBV</string>
+            </property>
+            <property name="rules" stdset="0">
+             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]==\&quot;SC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
+            </property>
+            <property name="precision" stdset="0">
+             <number>0</number>
+            </property>
+            <property name="showUnits" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="precisionFromPV" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="alarmSensitiveContent" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="alarmSensitiveBorder" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="PyDMToolTip" stdset="0">
+             <string/>
+            </property>
+            <property name="channel" stdset="0">
+             <string>ca://${line_arbiter_prefix}RequestedBP:BeamClass_RBV</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QLabel" name="label_4">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Requested</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="PyDMLabel" name="PyDMLabel_41">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="text">
+             <string>NC Rate</string>
+            </property>
+            <property name="rules" stdset="0">
+             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]==\&quot;NC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
+            </property>
+            <property name="precision" stdset="0">
+             <number>0</number>
+            </property>
+            <property name="showUnits" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="precisionFromPV" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="alarmSensitiveContent" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="alarmSensitiveBorder" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="PyDMToolTip" stdset="0">
+             <string/>
+            </property>
+            <property name="channel" stdset="0">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="PyDMLabel" name="PyDMLabel_42">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="text">
+             <string>SC Beam Class</string>
+            </property>
+            <property name="rules" stdset="0">
+             <string>[{&quot;name&quot;: &quot;Mode Visibility&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;initial_value&quot;: &quot;1&quot;, &quot;expression&quot;: &quot;ch[0]==\&quot;SC\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://${accelerator_mode_pv}&quot;, &quot;trigger&quot;: true, &quot;use_enum&quot;: true}]}]</string>
+            </property>
+            <property name="precision" stdset="0">
+             <number>0</number>
+            </property>
+            <property name="showUnits" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="precisionFromPV" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="alarmSensitiveContent" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="alarmSensitiveBorder" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="PyDMToolTip" stdset="0">
+             <string/>
+            </property>
+            <property name="channel" stdset="0">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="PyDMLabel" name="PyDMLabel_43">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="text">
+             <string>Transmission</string>
             </property>
            </widget>
           </item>
@@ -1390,7 +1599,7 @@
       <attribute name="title">
        <string>Grafana Log Display</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_9" stretch=""/>
+      <layout class="QVBoxLayout" name="verticalLayout_9"/>
      </widget>
     </widget>
    </item>

--- a/preemptive_requests.py
+++ b/preemptive_requests.py
@@ -10,7 +10,7 @@ from pydm.widgets import PyDMByteIndicator, PyDMEmbeddedDisplay, PyDMLabel
 from pydm.widgets.channel import PyDMChannel
 from qtpy import QtCore, QtWidgets
 
-from beamclass_table import get_tooltip_for_bc
+from beamclass_table import get_tooltip_for_bc, install_bc_setText
 from data_bounds import get_valid_rate
 
 logger = logging.getLogger(__name__)
@@ -129,6 +129,7 @@ class PreemptiveRequests(Display):
                 )
                 bc_channel.connect()
                 self._channels.append(bc_channel)
+                install_bc_setText(beamclass_label)
 
                 # insert the widget you see into the table
                 row_position = reqs_table.rowCount()

--- a/preemptive_requests.py
+++ b/preemptive_requests.py
@@ -210,6 +210,7 @@ class PreemptiveRequests(Display):
         # Show both if value is None
         header.rate_header.setVisible(self.mode != 'SC')
         header.beamclass_header.setVisible(self.mode != 'NC')
+        header.beamclass_ranges_header.setVisible(self.mode != 'NC')
         # Full beam filter depends on the mode
         self.update_all_filters()
 
@@ -343,6 +344,7 @@ class PreemptiveRequests(Display):
         row_widget = table.cellWidget(row, 0).embedded_widget.ui
         row_widget.rate_label.setVisible(self.mode != 'SC')
         row_widget.beamclass_label.setVisible(self.mode != 'NC')
+        row_widget.beamclass_bytes.setVisible(self.mode != 'NC')
 
         full_beam = all((
             rate_cpt,
@@ -526,6 +528,15 @@ item_info_list = [
         widget_name='beamclass_label',
         widget_class=PyDMLabel,
         store_type=int,
+        data_type=int,
+        default=0,
+    ),
+    ItemInfo(
+        name='beamclass ranges',
+        select_text='Beam Class Ranges [SC]',
+        widget_name='beamclass_bytes',
+        widget_class=PyDMByteIndicator,
+        store_type=bitmask_count,
         data_type=int,
         default=0,
     ),

--- a/preemptive_requests.py
+++ b/preemptive_requests.py
@@ -377,7 +377,7 @@ class PreemptiveRequests(Display):
         label.setText(f'{valid_rate} Hz')
 
     def update_beamclass_tooltip(self, value, label):
-        label.PyDMToolTip = get_tooltip_for_bc('<pre>' + value + '</pre>')
+        label.PyDMToolTip = get_tooltip_for_bc(value)
 
     def ui_filename(self):
         return 'preemptive_requests.ui'

--- a/preemptive_requests.py
+++ b/preemptive_requests.py
@@ -185,23 +185,7 @@ class PreemptiveRequests(Display):
         This will hide or show the rate and beamclass columns as appropriate
         and re-interpret the definition of "full beam".
         """
-        if isinstance(value, int):
-            self.mode_index = value
-            if self.mode_enum is None:
-                return
-            try:
-                self.mode = self.mode_enum[self.mode_index]
-            except IndexError:
-                logger.error(
-                    'Bad mode enum strs %s for index %d',
-                    self.mode_enum,
-                    self.mode_index,
-                )
-                self.mode = None
-        elif isinstance(value, str):
-            self.mode = value
-        else:
-            self.mode = None
+        self.mode = value
         header = self.ui.table_header.embedded_widget.ui
         # Show both if value is None
         header.rate_header.setVisible(self.mode != 'SC')
@@ -210,27 +194,11 @@ class PreemptiveRequests(Display):
         # Full beam filter depends on the mode
         self.update_all_filters()
 
-    def new_mode_enum_strs(self, value):
-        """
-        Update the enum strings used to interpret the mode.
-
-        Re-runs new_mode if we have an index already.
-        """
-        self.mode_enum = value
-        if self.mode_index is not None:
-            self.new_mode(self.mode_index)
-
     def setup_mode(self):
         """Create a channel to react to mode changes"""
-        mode_pvname = self.config.get('accelerator_mode_pv')
-        if not mode_pvname:
-            # We'll run in ambiguous mode
-            logger.warning('No accelerator_mode_pv in config file.')
-            return
         self._mode_channel = PyDMChannel(
-            f'ca://{mode_pvname}',
+            'loc://selected_mode',
             value_slot=self.new_mode,
-            enum_strings_slot=self.new_mode_enum_strs,
         )
         self._mode_channel.connect()
         self._channels.append(self._mode_channel)

--- a/preemptive_requests.py
+++ b/preemptive_requests.py
@@ -5,6 +5,7 @@ import typing
 from dataclasses import dataclass
 from string import Template
 
+import prettytable
 from pydm import Display
 from pydm.widgets import PyDMByteIndicator, PyDMEmbeddedDisplay, PyDMLabel
 from pydm.widgets.channel import PyDMChannel
@@ -115,6 +116,20 @@ class PreemptiveRequests(Display):
                 rate_channel.connect()
                 self._channels.append(rate_channel)
 
+                # Extra channel for the beamclass
+                # This lets us sub in an appropriate tooltip stub based on
+                # the beamclass value as it updates
+                beamclass_label = widget.embedded_widget.ui.beamclass_label
+                bc_channel = PyDMChannel(
+                    beamclass_label.channel,
+                    value_slot=functools.partial(
+                        self.update_beamclass_tooltip,
+                        label=beamclass_label,
+                    ),
+                )
+                bc_channel.connect()
+                self._channels.append(bc_channel)
+
                 # insert the widget you see into the table
                 row_position = reqs_table.rowCount()
                 reqs_table.insertRow(row_position)
@@ -220,8 +235,8 @@ class PreemptiveRequests(Display):
             value_slot=self.new_mode,
             enum_strings_slot=self.new_mode_enum_strs,
         )
-        self._channels.append(self._mode_channel)
         self._mode_channel.connect()
+        self._channels.append(self._mode_channel)
 
     def sort_table(self, column, ascending):
         """
@@ -360,6 +375,9 @@ class PreemptiveRequests(Display):
     def update_valid_rate(self, value, label):
         valid_rate = get_valid_rate(value)
         label.setText(f'{valid_rate} Hz')
+
+    def update_beamclass_tooltip(self, value, label):
+        label.PyDMToolTip = get_tooltip_for_bc(value)
 
     def ui_filename(self):
         return 'preemptive_requests.ui'
@@ -548,3 +566,49 @@ item_info_list = [
         default=0,
     ),
 ]
+
+# Copied from https://confluence.slac.stanford.edu/pages/viewpage.action?pageId=341246543 and tweaked
+bc_header = """
+Index	Display Name	∆T (s)	dt (s)	Q (pC)	Rate max (Hz)	Current (nA)	Power @ 4 GeV (W)	Int. Energy @ 4 GeV (J)	Notes
+""".strip().split('\t')
+bc_table = """
+0	Beam Off	0.5	-	0	0	0	0	0	Beam off, Kickers off
+1	Kicker STBY	0.5	-	0	0	0	0	0	Beam off, Kickers standby
+2	BC1Hz	1	1	350	1	0.35	1.4	1.4	350 pC x 1 Hz
+3	BC10Hz	1	0.1	3500	10	3.5	14	14	350 pC X 10 Hz
+4	Diagnostic	0.5	-	5000	-	10	40	20	50 pC x 200 Hz
+5	BC120Hz	0.2	0.0083	6000	120	30	120	24	250 pC x 120 Hz
+6	Tuning	0.2	-	7000	-	35	140	28	100 pC X 350 Hz
+7	1% MAP	0.01	-	3000	-	300	1200	12	100 pC X 3 kHz
+8	5% MAP	0.003	-	4500	-	1500	6000	18	100 pC x 15 kHz
+9	10% MAP	0.001	-	3000	-	3000	12000	12	100 pC X 30 kHz
+10	25% MAP	4e-4	-	3000	-	7500	30000	12	100 pC x 75 kHz
+11	50% MAP	2e-1	-	3000	-	15000	60000	12	100 pC x 150 kHz
+12	100% MAP	2e-4	-	6000	-	30000	120000	24	100 pC x 300 kHz
+13	Unlimited	-	-	-	-	-	-	-	-
+14	Spare	-	-	-	-	-	-	-	-
+15	Spare	-	-	-	-	-	-	-	-
+""".strip().split('\n')
+for index, row in enumerate(bc_table):
+    bc_table[index] = row.split('\t')
+
+
+def get_full_bc_table() -> str:
+    """
+    Show the full table
+    """
+    table = prettytable.PrettyTable()
+    table.field_names = bc_header
+    for row in bc_table:
+        table.add_row(row)
+    return str(table)
+
+
+def get_tooltip_for_bc(beamclass: int) -> str:
+    """
+    Create a mini 2-row table suitable for a beam class tooltip.
+    """
+    table = prettytable.PrettyTable()
+    table.field_names = bc_header
+    table.add_row(bc_table[beamclass])
+    return str(table)

--- a/preemptive_requests.py
+++ b/preemptive_requests.py
@@ -5,12 +5,12 @@ import typing
 from dataclasses import dataclass
 from string import Template
 
-import prettytable
 from pydm import Display
 from pydm.widgets import PyDMByteIndicator, PyDMEmbeddedDisplay, PyDMLabel
 from pydm.widgets.channel import PyDMChannel
 from qtpy import QtCore, QtWidgets
 
+from beamclass_table import get_tooltip_for_bc
 from data_bounds import get_valid_rate
 
 logger = logging.getLogger(__name__)
@@ -566,49 +566,3 @@ item_info_list = [
         default=0,
     ),
 ]
-
-# Copied from https://confluence.slac.stanford.edu/pages/viewpage.action?pageId=341246543 and tweaked
-bc_header = """
-Index	Display Name	∆T (s)	dt (s)	Q (pC)	Rate max (Hz)	Current (nA)	Power @ 4 GeV (W)	Int. Energy @ 4 GeV (J)	Notes
-""".strip().split('\t')
-bc_table = """
-0	Beam Off	0.5	-	0	0	0	0	0	Beam off, Kickers off
-1	Kicker STBY	0.5	-	0	0	0	0	0	Beam off, Kickers standby
-2	BC1Hz	1	1	350	1	0.35	1.4	1.4	350 pC x 1 Hz
-3	BC10Hz	1	0.1	3500	10	3.5	14	14	350 pC X 10 Hz
-4	Diagnostic	0.5	-	5000	-	10	40	20	50 pC x 200 Hz
-5	BC120Hz	0.2	0.0083	6000	120	30	120	24	250 pC x 120 Hz
-6	Tuning	0.2	-	7000	-	35	140	28	100 pC X 350 Hz
-7	1% MAP	0.01	-	3000	-	300	1200	12	100 pC X 3 kHz
-8	5% MAP	0.003	-	4500	-	1500	6000	18	100 pC x 15 kHz
-9	10% MAP	0.001	-	3000	-	3000	12000	12	100 pC X 30 kHz
-10	25% MAP	4e-4	-	3000	-	7500	30000	12	100 pC x 75 kHz
-11	50% MAP	2e-1	-	3000	-	15000	60000	12	100 pC x 150 kHz
-12	100% MAP	2e-4	-	6000	-	30000	120000	24	100 pC x 300 kHz
-13	Unlimited	-	-	-	-	-	-	-	-
-14	Spare	-	-	-	-	-	-	-	-
-15	Spare	-	-	-	-	-	-	-	-
-""".strip().split('\n')
-for index, row in enumerate(bc_table):
-    bc_table[index] = row.split('\t')
-
-
-def get_full_bc_table() -> str:
-    """
-    Show the full table
-    """
-    table = prettytable.PrettyTable()
-    table.field_names = bc_header
-    for row in bc_table:
-        table.add_row(row)
-    return str(table)
-
-
-def get_tooltip_for_bc(beamclass: int) -> str:
-    """
-    Create a mini 2-row table suitable for a beam class tooltip.
-    """
-    table = prettytable.PrettyTable()
-    table.field_names = bc_header
-    table.add_row(bc_table[beamclass])
-    return str(table)

--- a/preemptive_requests.py
+++ b/preemptive_requests.py
@@ -377,7 +377,7 @@ class PreemptiveRequests(Display):
         label.setText(f'{valid_rate} Hz')
 
     def update_beamclass_tooltip(self, value, label):
-        label.PyDMToolTip = get_tooltip_for_bc(value)
+        label.PyDMToolTip = get_tooltip_for_bc('<pre>' + value + '</pre>')
 
     def ui_filename(self):
         return 'preemptive_requests.ui'

--- a/preemptive_requests.py
+++ b/preemptive_requests.py
@@ -11,9 +11,10 @@ from pydm.widgets import PyDMByteIndicator, PyDMEmbeddedDisplay, PyDMLabel
 from pydm.widgets.channel import PyDMChannel
 from qtpy import QtCore, QtWidgets
 
-from beamclass_table import (get_max_bc_from_bitmask, get_tooltip_for_bc,
-                             get_tooltip_for_bc_bitmask, install_bc_setText)
+from beamclass_table import get_max_bc_from_bitmask, install_bc_setText
 from data_bounds import get_valid_rate
+from tooltips import (get_ev_range_tooltip, get_tooltip_for_bc,
+                      get_tooltip_for_bc_bitmask)
 
 logger = logging.getLogger(__name__)
 
@@ -515,44 +516,7 @@ class BCRowLogic(QtCore.QObject):
             self.last_ev_range = value
         if self.ev_ranges is None:
             return
-
-        ev_range = value
-
-        bounds = []
-        curr_bound = None
-        prev = 0
-
-        for bit, ev in enumerate(self.ev_ranges):
-            ok = (ev_range >> bit) % 2
-            if ok:
-                if curr_bound is None:
-                    curr_bound = (prev, ev)
-                else:
-                    curr_bound = (curr_bound[0], ev)
-            else:
-                if curr_bound is not None:
-                    bounds.append(curr_bound)
-                    curr_bound = None
-            prev = ev
-
-        if curr_bound is not None:
-            bounds.append(curr_bound)
-
-        if bounds:
-            left_width = 0
-            right_width = 0
-            for left, right in bounds:
-                left_width = max(left_width, len(str(left)))
-                right_width = max(right_width, len(str(right)))
-            lines = []
-            for under, over in bounds:
-                line = f'Allow {under:{left_width}}eV &lt; energy &lt; {over:{right_width}}eV'
-                lines.append(line)
-            text = '\n'.join(lines)
-        else:
-            text = 'No eV range allowed.'
-
-        self.ev_bytes.PyDMToolTip = '<pre>' + text + '</pre>'
+        self.ev_bytes.PyDMToolTip = get_ev_range_tooltip(value, self.ev_ranges)
 
 
 @dataclass(frozen=True)

--- a/preemptive_requests.ui
+++ b/preemptive_requests.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1208</width>
+    <width>1218</width>
     <height>242</height>
    </rect>
   </property>
@@ -175,6 +175,12 @@
    </item>
    <item>
     <widget class="Line" name="line">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="maximumSize">
       <size>
        <width>1190</width>
@@ -187,7 +193,7 @@
     </widget>
    </item>
    <item>
-    <widget class="PyDMEmbeddedDisplay" name="PyDMEmbeddedDisplay">
+    <widget class="PyDMEmbeddedDisplay" name="table_header">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
@@ -211,6 +217,9 @@
      </property>
      <property name="filename" stdset="0">
       <string>templates/preemptive_requests_header.ui</string>
+     </property>
+     <property name="loadWhenShown" stdset="0">
+      <bool>false</bool>
      </property>
      <property name="disconnectWhenHidden" stdset="0">
       <bool>false</bool>

--- a/preemptive_requests.ui
+++ b/preemptive_requests.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1218</width>
+    <width>1471</width>
     <height>242</height>
    </rect>
   </property>
@@ -228,6 +228,12 @@
    </item>
    <item>
     <widget class="QTableWidget" name="reqs_table_widget">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::NoSelection</enum>
+     </property>
      <property name="showGrid">
       <bool>true</bool>
      </property>

--- a/templates/preemptive_requests_entry.ui
+++ b/templates/preemptive_requests_entry.ui
@@ -6,19 +6,19 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1412</width>
+    <width>1453</width>
     <height>40</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>1412</width>
+    <width>1453</width>
     <height>40</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>1412</width>
+    <width>1453</width>
     <height>40</height>
    </size>
   </property>
@@ -193,7 +193,7 @@
      </property>
      <property name="minimumSize">
       <size>
-       <width>186</width>
+       <width>183</width>
        <height>16</height>
       </size>
      </property>
@@ -327,22 +327,6 @@
     </widget>
    </item>
    <item>
-    <spacer name="horizontalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Minimum</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>10</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
     <widget class="PyDMLabel" name="cohort_label">
      <property name="enabled">
       <bool>false</bool>
@@ -377,19 +361,6 @@
     </widget>
    </item>
    <item>
-    <spacer name="horizontalSpacer_3">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
     <widget class="PyDMByteIndicator" name="live_byte">
      <property name="enabled">
       <bool>false</bool>
@@ -402,13 +373,13 @@
      </property>
      <property name="minimumSize">
       <size>
-       <width>80</width>
+       <width>150</width>
        <height>32</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>80</width>
+       <width>150</width>
        <height>32</height>
       </size>
      </property>

--- a/templates/preemptive_requests_entry.ui
+++ b/templates/preemptive_requests_entry.ui
@@ -6,19 +6,19 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1392</width>
+    <width>1412</width>
     <height>40</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>1392</width>
+    <width>1412</width>
     <height>40</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>1392</width>
+    <width>1412</width>
     <height>40</height>
    </size>
   </property>
@@ -153,24 +153,27 @@
      </property>
      <property name="minimumSize">
       <size>
-       <width>100</width>
+       <width>120</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>100</width>
+       <width>120</width>
        <height>16777215</height>
       </size>
      </property>
      <property name="toolTip">
       <string/>
      </property>
+     <property name="text">
+      <string>loc://${P}${ARBITER}${POOL}:MaxBC?type=int&amp;init=0</string>
+     </property>
      <property name="showUnits" stdset="0">
       <bool>true</bool>
      </property>
      <property name="channel" stdset="0">
-      <string>ca://${P}${ARBITER}:AP:Entry:${POOL}:BeamClass_RBV</string>
+      <string>loc://${P}${ARBITER}${POOL}:MaxBC?type=int&amp;init=0</string>
      </property>
      <property name="displayFormat" stdset="0">
       <enum>PyDMLabel::Default</enum>

--- a/templates/preemptive_requests_entry.ui
+++ b/templates/preemptive_requests_entry.ui
@@ -6,19 +6,19 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1206</width>
+    <width>1392</width>
     <height>40</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>1206</width>
+    <width>1392</width>
     <height>40</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>1206</width>
+    <width>1392</width>
     <height>40</height>
    </size>
   </property>
@@ -178,6 +178,59 @@
     </widget>
    </item>
    <item>
+    <widget class="PyDMByteIndicator" name="beamclass_bytes">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>186</width>
+       <height>16</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>183</width>
+       <height>16</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${P}${ARBITER}:AP:Entry:${POOL}:BeamClassRanges_RBV</string>
+     </property>
+     <property name="onColor" stdset="0">
+      <color>
+       <red>21</red>
+       <green>165</green>
+       <blue>62</blue>
+      </color>
+     </property>
+     <property name="orientation" stdset="0">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="showLabels" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="bigEndian" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="circles" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="numBits" stdset="0">
+      <number>15</number>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="PyDMLabel" name="transmission_label">
      <property name="enabled">
       <bool>false</bool>
@@ -202,6 +255,9 @@
      </property>
      <property name="toolTip">
       <string/>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
      </property>
      <property name="showUnits" stdset="0">
       <bool>true</bool>

--- a/templates/preemptive_requests_entry.ui
+++ b/templates/preemptive_requests_entry.ui
@@ -122,6 +122,37 @@
      </property>
      <property name="minimumSize">
       <size>
+       <width>50</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>50</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QLabel { color : black; }</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMLabel" name="beamclass_label">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
        <width>100</width>
        <height>0</height>
       </size>
@@ -132,11 +163,17 @@
        <height>16777215</height>
       </size>
      </property>
-     <property name="styleSheet">
-      <string notr="true">QLabel { color : black; }</string>
-     </property>
-     <property name="text">
+     <property name="toolTip">
       <string/>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${P}${ARBITER}:AP:Entry:${POOL}:BeamClass_RBV</string>
+     </property>
+     <property name="displayFormat" stdset="0">
+      <enum>PyDMLabel::Default</enum>
      </property>
     </widget>
    </item>

--- a/templates/preemptive_requests_header.ui
+++ b/templates/preemptive_requests_header.ui
@@ -160,7 +160,35 @@
           <enum>QLayout::SetFixedSize</enum>
          </property>
          <item>
-          <widget class="QLabel" name="label_10">
+          <widget class="QLabel" name="rate_header">
+           <property name="minimumSize">
+            <size>
+             <width>50</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>100</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Rate</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="beamclass_header">
            <property name="minimumSize">
             <size>
              <width>100</width>
@@ -180,7 +208,7 @@
             </font>
            </property>
            <property name="text">
-            <string>Rate</string>
+            <string>Beam Class</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -326,15 +354,21 @@
    </item>
    <item>
     <widget class="Line" name="line">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="minimumSize">
       <size>
-       <width>1056</width>
+       <width>1190</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>1056</width>
+       <width>1190</width>
        <height>16777215</height>
       </size>
      </property>

--- a/templates/preemptive_requests_header.ui
+++ b/templates/preemptive_requests_header.ui
@@ -6,13 +6,13 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1459</width>
+    <width>1453</width>
     <height>47</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>1459</width>
+    <width>1453</width>
     <height>47</height>
    </size>
   </property>
@@ -120,13 +120,13 @@
         <widget class="QLabel" name="label_4">
          <property name="minimumSize">
           <size>
-           <width>600</width>
+           <width>200</width>
            <height>0</height>
           </size>
          </property>
          <property name="maximumSize">
           <size>
-           <width>600</width>
+           <width>16777215</width>
            <height>16777215</height>
           </size>
          </property>
@@ -161,6 +161,12 @@
          </property>
          <item>
           <widget class="QLabel" name="rate_header">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="minimumSize">
             <size>
              <width>50</width>
@@ -169,7 +175,7 @@
            </property>
            <property name="maximumSize">
             <size>
-             <width>100</width>
+             <width>50</width>
              <height>16777215</height>
             </size>
            </property>
@@ -251,6 +257,12 @@
          </item>
          <item>
           <widget class="QLabel" name="label_12">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="minimumSize">
             <size>
              <width>100</width>
@@ -279,6 +291,12 @@
          </item>
          <item>
           <widget class="QLabel" name="label_11">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="minimumSize">
             <size>
              <width>400</width>
@@ -311,6 +329,12 @@
      </item>
      <item>
       <widget class="QLabel" name="label_6">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="minimumSize">
         <size>
          <width>150</width>
@@ -342,6 +366,12 @@
      </item>
      <item>
       <widget class="QLabel" name="label_7">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="minimumSize">
         <size>
          <width>150</width>
@@ -389,20 +419,20 @@
    <item>
     <widget class="Line" name="line">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
      <property name="minimumSize">
       <size>
-       <width>1210</width>
+       <width>100</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>1210</width>
+       <width>1453</width>
        <height>16777215</height>
       </size>
      </property>

--- a/templates/preemptive_requests_header.ui
+++ b/templates/preemptive_requests_header.ui
@@ -6,19 +6,19 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1396</width>
+    <width>1459</width>
     <height>47</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>1396</width>
+    <width>1459</width>
     <height>47</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>1396</width>
+    <width>1459</width>
     <height>47</height>
    </size>
   </property>
@@ -189,15 +189,21 @@
          </item>
          <item>
           <widget class="QLabel" name="beamclass_header">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="minimumSize">
             <size>
-             <width>100</width>
+             <width>120</width>
              <height>0</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
-             <width>100</width>
+             <width>120</width>
              <height>16777215</height>
             </size>
            </property>
@@ -208,7 +214,7 @@
             </font>
            </property>
            <property name="text">
-            <string>Beam Class</string>
+            <string>Max Beam Class</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -390,13 +396,13 @@
      </property>
      <property name="minimumSize">
       <size>
-       <width>1190</width>
+       <width>1210</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>1190</width>
+       <width>1210</width>
        <height>16777215</height>
       </size>
      </property>

--- a/templates/preemptive_requests_header.ui
+++ b/templates/preemptive_requests_header.ui
@@ -6,19 +6,19 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1206</width>
+    <width>1396</width>
     <height>47</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>1206</width>
+    <width>1396</width>
     <height>47</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>1206</width>
+    <width>1396</width>
     <height>47</height>
    </size>
   </property>
@@ -216,6 +216,34 @@
           </widget>
          </item>
          <item>
+          <widget class="QLabel" name="beamclass_ranges_header">
+           <property name="minimumSize">
+            <size>
+             <width>183</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>183</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Beam Class Ranges</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QLabel" name="label_12">
            <property name="minimumSize">
             <size>
@@ -239,7 +267,7 @@
             <string>Transmission</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            <set>Qt::AlignCenter</set>
            </property>
           </widget>
          </item>

--- a/tooltips.py
+++ b/tooltips.py
@@ -1,0 +1,74 @@
+from typing import Iterable
+
+import prettytable
+
+from beamclass_table import bc_header, bc_table
+
+
+def preformatted(text: str) -> str:
+    """Return a rich text preformatted version of input."""
+    return f'<pre>{text}</pre>'
+
+
+def get_ev_range_tooltip(bitmask: int, range_def: Iterable[int]) -> str:
+    """Return a suitable tooltip for an eV range bitmask."""
+    bounds = []
+    curr_bound = None
+    prev = 0
+
+    for bit, ev in enumerate(range_def):
+        ok = (bitmask >> bit) % 2
+        if ok:
+            if curr_bound is None:
+                curr_bound = (prev, ev)
+            else:
+                curr_bound = (curr_bound[0], ev)
+        else:
+            if curr_bound is not None:
+                bounds.append(curr_bound)
+                curr_bound = None
+        prev = ev
+
+    if curr_bound is not None:
+        bounds.append(curr_bound)
+
+    if bounds:
+        left_width = 0
+        right_width = 0
+        for left, right in bounds:
+            left_width = max(left_width, len(str(left)))
+            right_width = max(right_width, len(str(right)))
+        lines = []
+        for under, over in bounds:
+            line = f'Allow {under:{left_width}}eV &lt; energy &lt; {over:{right_width}}eV'
+            lines.append(line)
+        text = '\n'.join(lines)
+    else:
+        text = 'No eV range allowed.'
+    return preformatted(text)
+
+
+def get_tooltip_for_bc(beamclass: int) -> str:
+    """
+    Create a mini 2-row table suitable for a beam class tooltip.
+    """
+    table = prettytable.PrettyTable()
+    table.field_names = bc_header
+    table.add_row(bc_table[beamclass])
+    return preformatted(str(table))
+
+
+def get_tooltip_for_bc_bitmask(bitmask: int) -> str:
+    """
+    Create a partial table suitable for a bitmask tooltip.
+    """
+    table = prettytable.PrettyTable()
+    table.field_names = bc_header
+    table.add_row(bc_table[0])
+    count = 0
+    while bitmask > 0:
+        count += 1
+        if bitmask % 2:
+            table.add_row(bc_table[count])
+        bitmask = bitmask >> 1
+    return preformatted(str(table))

--- a/tooltips.py
+++ b/tooltips.py
@@ -46,7 +46,7 @@ def get_ev_range_tooltip(bitmask: int, range_def: Iterable[int]) -> str:
     left_width = 0
     right_width = 0
     lines = []
-    if not bad_bounds or len(ok_bounds) < len(bad_bounds):
+    if not bad_bounds or (ok_bounds and len(ok_bounds) < len(bad_bounds)):
         for left, right in ok_bounds:
             left_width = max(left_width, len(str(left)))
             right_width = max(right_width, len(str(right)))

--- a/tooltips.py
+++ b/tooltips.py
@@ -1,6 +1,7 @@
 from typing import Iterable
 
 import prettytable
+from qtpy import QtCore, QtWidgets
 
 from beamclass_table import bc_header, bc_table
 
@@ -88,3 +89,27 @@ def get_tooltip_for_bc_bitmask(bitmask: int) -> str:
             table.add_row(bc_table[count])
         bitmask = bitmask >> 1
     return preformatted(str(table))
+
+
+def get_mode_tooltip_lines() -> list[str]:
+    """
+    Get the individual lines that make up the mode tooltip.
+    """
+    return [
+        'Auto: show NC or SC fields based on the mode PV',
+        'NC: show only the NC fields',
+        'SC: show only the SC fields',
+        'Both: show all fields'
+    ]
+
+
+def setup_combobox_tooltip(widget: QtWidgets.QComboBox, lines: list[str]):
+    """
+    Set up a standard tooltip on a combobox.
+
+    The full widget will show all the lines as a tooltip
+    and each item will show its individual tooltip when selected.
+    """
+    widget.setToolTip('\n'.join(lines))
+    for index, line in enumerate(lines):
+        widget.setItemData(index, line, QtCore.Qt.ToolTipRole)

--- a/tooltips.py
+++ b/tooltips.py
@@ -52,14 +52,14 @@ def get_ev_range_tooltip(bitmask: int, range_def: Iterable[int]) -> str:
             left_width = max(left_width, len(str(left)))
             right_width = max(right_width, len(str(right)))
         for under, over in ok_bounds:
-            line = f'Allow {under:{left_width}} eV &lt; energy &lt; {over:{right_width}} eV'
+            line = f'Allow {under:{left_width}} eV to {over:{right_width}} eV'
             lines.append(line)
     else:
         for left, right in bad_bounds:
             left_width = max(left_width, len(str(left)))
             right_width = max(right_width, len(str(right)))
         for under, over in bad_bounds:
-            line = f'Block {under:{left_width}} eV &lt; energy &lt; {over:{right_width}} eV'
+            line = f'Block {under:{left_width}} eV to {over:{right_width}} eV'
             lines.append(line)
     return preformatted('\n'.join(lines))
 

--- a/tooltips.py
+++ b/tooltips.py
@@ -19,6 +19,7 @@ def get_ev_range_tooltip(bitmask: int, range_def: Iterable[int]) -> str:
     prev = 0
 
     for bit, ev in enumerate(range_def):
+        ev = int(ev)
         ok = (bitmask >> bit) % 2
         if ok:
             if curr_ok_bound is None:
@@ -51,14 +52,14 @@ def get_ev_range_tooltip(bitmask: int, range_def: Iterable[int]) -> str:
             left_width = max(left_width, len(str(left)))
             right_width = max(right_width, len(str(right)))
         for under, over in ok_bounds:
-            line = f'Allow {under:{left_width}}eV &lt; energy &lt; {over:{right_width}}eV'
+            line = f'Allow {under:{left_width}} eV &lt; energy &lt; {over:{right_width}} eV'
             lines.append(line)
     else:
         for left, right in bad_bounds:
             left_width = max(left_width, len(str(left)))
             right_width = max(right_width, len(str(right)))
         for under, over in bad_bounds:
-            line = f'Block {under:{left_width}}eV &lt; energy &lt; {over:{right_width}}eV'
+            line = f'Block {under:{left_width}} eV &lt; energy &lt; {over:{right_width}} eV'
             lines.append(line)
     return preformatted('\n'.join(lines))
 

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,7 @@
 from qtpy import QtCore, QtGui, QtWidgets
 
 
-def morph_into_vertical(label):
+def morph_into_vertical(label: QtWidgets.QLabel):
     def minimumSizeHint(*args, **kwargs):
         s = QtWidgets.QLabel.minimumSizeHint(label)
         return QtCore.QSize(s.height(), s.width())
@@ -26,6 +26,9 @@ def morph_into_vertical(label):
         # center the text on the bitmask
         pos_y = -(label_w - text_h)
         painter.drawText(pos_x, pos_y, label.text())
+
+    # Unbind the size restrictions from the ui file that make it viewable in designer
+    label.setMaximumWidth(label.maximumHeight())
 
     label.minimumSizeHint = minimumSizeHint
     label.sizeHint = sizeHint

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,33 @@
+from qtpy import QtCore, QtGui, QtWidgets
+
+
+def morph_into_vertical(label):
+    def minimumSizeHint(*args, **kwargs):
+        s = QtWidgets.QLabel.minimumSizeHint(label)
+        return QtCore.QSize(s.height(), s.width())
+
+    def sizeHint(*args, **kwargs):
+        s = QtWidgets.QLabel.sizeHint(label)
+        return QtCore.QSize(s.height(), s.width())
+
+    def paintEvent(*args, **kwargs):
+        painter = QtGui.QPainter(label)
+        painter.translate(label.sizeHint().width(), label.sizeHint().height())
+        painter.rotate(270)
+
+        # size of text inside the label widget
+        text_w = label.fontMetrics().boundingRect(label.text()).width()
+        text_h = label.fontMetrics().boundingRect(label.text()).height()
+        # size of label widget
+        label_h = label.sizeHint().height()
+        label_w = label.sizeHint().width()
+        # this will make it look like it is right (or top) justified
+        pos_x = label_h - text_w
+        # center the text on the bitmask
+        pos_y = -(label_w - text_h)
+        painter.drawText(pos_x, pos_y, label.text())
+
+    label.minimumSizeHint = minimumSizeHint
+    label.sizeHint = sizeHint
+    label.paintEvent = paintEvent
+    label.update()


### PR DESCRIPTION
This is deployed as-is for `lpmps` and `kpmps`. `kpmps` isn't quite ready yet for the new PVs.

Some of the code is a little messy, sorry about that.

Big ideas:
- Now supports the superconducting "beam class" concept where applicable.
- Now has three modes: "NC" mode, "SC" mode, and "Both" mode to reduce clutter. The "Auto" mode will pick NC or SC depending on what the PV says, or both if the PV is disconnected.
- Added a beam class tab that shows all the beam class definitions.
- Added tooltips for eV ranges and beamclasses to help understand what is being done.
- Various logic and layout fixes.

Original to-do list:
- [x] Test again once we update the PLCs + their IOCs
- [x] Add beam mode (NC vs SC) to the top of the page
- [x] Show current beam class instead of current rate at top of the page when in SC mode
- [x] Add beam class and/or beam class range to pre-emptive request table
- [x] Add beam class and/or beam class range to control page 
- [x] Add a beamclass table tab
- [x] Add beamclass tooltip wherever relevant
- [x] Add the beamclass bitmask to the pre-emptive requests tab
- [x] Remove GEM from LFE arbiter configuration
- [x] Show beam class name, not just number
- [x] Show max beam class summary column in preemptive requests page instead of the 0: no beam PV
- [x] Resolve behavior of UI in requesting beam classes (BC range vs BC selector? Summarize in PLC or in UI?)
- [x] Add tooltip for bc range
- [x] Add tooltip for ev range
- [x] Switch for turning the auto show/hide off and on
- [x] Improve photon energy range tooltip - summarize over spam
- [x] add line beam parameter control readbacks for the bitmasks
- [x] Arbiter outputs tab on the left is pretty bad, it needs to be remapped to the 4 bits we picked
- [x] refactor tooltips and add to line beam parameters page
- [x] plc ioc status handling for missing cycle 2 and 3 pvs
- [x] even better ev tooltip: use the "denied" ranges if it's a shorter summary

And maybe more?