### PR TITLE
ENH: handle invalid beam classes in tooltip

### DIFF
--- a/beamclass_table.py
+++ b/beamclass_table.py
@@ -56,11 +56,21 @@ for index, row in enumerate(bc_table):
     bc_table[index] = row.split('\t')
 
 
+def get_table_row(row: int) -> list[str]:
+    """
+    Grab a row from the table, or invalid if out of range.
+    """
+    try:
+        return bc_table[row]
+    except IndexError:
+        return [row, 'Invalid'] + (['?'] * 8)
+
+
 def get_desc_for_bc(beamclass: int) -> str:
     """
     Get just the short description of a beamclass.
     """
-    return bc_table[beamclass][1]
+    return get_table_row(beamclass)[1]
 
 
 def install_bc_setText(widget: QLabel):

--- a/tooltips.py
+++ b/tooltips.py
@@ -3,7 +3,7 @@ from typing import Iterable
 import prettytable
 from qtpy import QtCore, QtWidgets
 
-from beamclass_table import bc_header, bc_table
+from beamclass_table import bc_header, get_table_row
 
 
 def preformatted(text: str) -> str:
@@ -71,7 +71,7 @@ def get_tooltip_for_bc(beamclass: int) -> str:
     """
     table = prettytable.PrettyTable()
     table.field_names = bc_header
-    table.add_row(bc_table[beamclass])
+    table.add_row(get_table_row(beamclass))
     return preformatted(str(table))
 
 
@@ -81,12 +81,12 @@ def get_tooltip_for_bc_bitmask(bitmask: int) -> str:
     """
     table = prettytable.PrettyTable()
     table.field_names = bc_header
-    table.add_row(bc_table[0])
+    table.add_row(get_table_row(0))
     count = 0
     while bitmask > 0:
         count += 1
         if bitmask % 2:
-            table.add_row(bc_table[count])
+            table.add_row(get_table_row(count))
         bitmask = bitmask >> 1
     return preformatted(str(table))
 


### PR DESCRIPTION
Handles a tooltip edge case when an invalid beam class is selected

So instead of crashing the tooltip it says something like "beamclass 1342 - Invalid - ? ? ? ? ? ? "

This has been live for a couple weeks