### PR TITLE
MAINT: backwards compatibility utils for PV name change

### DIFF
--- a/KFE_config.yml
+++ b/KFE_config.yml
@@ -1,6 +1,6 @@
 line_arbiter_prefix: "PMPS:KFE:"
 undulator_kicker_rate_pv: "IOC:BSY0:MP01:BYKIKS_RATE"
-accelerator_mode_pv: "SIOC:FEES:MP01:LCLSMODE_RBV"
+accelerator_mode_pv: "SIOC:FEES:MP01:FACMODE_RBV"
 
 dashboard_url: "http://ctl-logsrv01:3000/ctl/grafana/d/PRr2cuGGz/k-pmps-events?viewPanel=2&orgId=1&refresh=10s&kiosk"
 

--- a/KFE_config.yml
+++ b/KFE_config.yml
@@ -104,6 +104,16 @@ preemptive_requests:
     assertion_pool_start: 1
     assertion_pool_end: 20
 
+  - prefix: "PLC:TMO:OPTICS:"
+    arbiter_instance: "ARB:01"
+    assertion_pool_start: 1
+    assertion_pool_end: 20
+
+  - prefix: "PLC:TMO:OPTICS:"
+    arbiter_instance: "ARB:02"
+    assertion_pool_start: 1
+    assertion_pool_end: 20
+
   - prefix: "PLC:TMO:MOTION:"
     arbiter_instance: "ARB:01"
     assertion_pool_start: 1

--- a/LFE_config.yml
+++ b/LFE_config.yml
@@ -36,7 +36,7 @@ fastfaults:
     ff_start: 1
     ff_end: 50
 
-  - prefix: "PLC:XRT:HOMS:"
+  - prefix: "PLC:XRT:OPTICS:"
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
@@ -58,7 +58,7 @@ preemptive_requests:
     assertion_pool_start: 1
     assertion_pool_end: 20
 
-  - prefix: "PLC:XRT:HOMS:"
+  - prefix: "PLC:XRT:OPTICS:"
     arbiter_instance: "ARB:01"
     assertion_pool_start: 1
     assertion_pool_end: 20

--- a/LFE_config.yml
+++ b/LFE_config.yml
@@ -1,6 +1,6 @@
 line_arbiter_prefix: "PMPS:LFE:"
 undulator_kicker_rate_pv: "IOC:BSY0:MP01:BYKIK_RATE"
-accelerator_mode_pv: "SIOC:FEEH:MP01:LCLSMODE_RBV"
+accelerator_mode_pv: "SIOC:FEEH:MP01:FACMODE_RBV"
 
 dashboard_url: "http://ctl-logsrv01:3000/ctl/grafana/d/PQBzCnmMz/l-pmps-events?refresh=10s&kiosk"
 

--- a/TST_config.yml
+++ b/TST_config.yml
@@ -1,8 +1,8 @@
-line_arbiter_prefix: "PMPS:LFE:"
-undulator_kicker_rate_pv: "IOC:BSY0:MP01:BYKIK_RATE"
-accelerator_mode_pv: "SIOC:FEEH:MP01:LCLSMODE_RBV"
+line_arbiter_prefix: "PMPS:TST:"
+undulator_kicker_rate_pv: "PMPS:TST:BYKIK_RATE"
+accelerator_mode_pv: "PMPS:TST:LCLSMODE_RBV"
 
-dashboard_url: "http://ctl-logsrv01:3000/ctl/grafana/d/PQBzCnmMz/l-pmps-events?refresh=10s&kiosk"
+dashboard_url: "about:new"
 
 
 fastfaults:
@@ -13,7 +13,7 @@ fastfaults:
     ff_end: 50
 
 preemptive_requests:
-  - prefix: "PMPS:LFE:"
-    arbiter_instance: "Arbiter:01"
+  - prefix: "PLC:TST:MOT:"
+    arbiter_instance: "ARB"
     assertion_pool_start: 1
     assertion_pool_end: 20

--- a/beamclass_table.py
+++ b/beamclass_table.py
@@ -1,3 +1,5 @@
+import textwrap
+
 from pydm import Display
 from qtpy.QtWidgets import QLabel, QTableWidgetItem
 
@@ -17,6 +19,13 @@ class BeamclassTable(Display):
         self.ui.table.setColumnCount(len(bc_header))
         self.ui.table.setRowCount(len(bc_table))
         self.ui.table.setHorizontalHeaderLabels(bc_header)
+        for col_index, description in enumerate(bc_header_full_descriptions):
+            self.ui.table.horizontalHeaderItem(col_index).setToolTip(
+                textwrap.fill(
+                    description,
+                    width=40,
+                )
+            )
         for row_index, row_list in enumerate(bc_table):
             for col_index, text in enumerate(row_list):
                 self.ui.table.setItem(
@@ -25,6 +34,13 @@ class BeamclassTable(Display):
                     QTableWidgetItem(text),
                 )
         self.ui.table.resizeColumnsToContents()
+        self.ui.table.setFixedSize(
+            self.ui.table.horizontalHeader().length()
+            + self.ui.table.verticalHeader().width(),
+            self.ui.table.verticalHeader().length()
+            + self.ui.table.horizontalHeader().height(),
+        )
+        self.ui.source_links_text.setFixedWidth(self.ui.table.width())
 
     def ui_filename(self):
         return 'beamclass_table.ui'
@@ -54,6 +70,19 @@ bc_table = """
 """.strip().split('\n')
 for index, row in enumerate(bc_table):
     bc_table[index] = row.split('\t')
+
+bc_header_full_descriptions = [
+    'Index is the beamclass number. When we say "beamclass 10", we are referring to index 10 on this table.',
+    'Display name is a short, human-readable name that is a minimal description of how the beamclass behaves.',
+    '∆T (s) is the integration time window used for the Q (pC) charge measurement. A beamclass limits the amount of integrated electron charge during a time interval.',
+    'dt (s) is the the minimum bunch spacing (including non-periodic bunch patterns). This effectively limits the rep rate of the beam for periodic bunch patterns.',
+    'Q (pC) is the the maximum beam charge integrated in ∆T (s). A beamclass limits the amount of integrated electron charge during a time interval.',
+    'Rate max (Hz) is a field calculated from dt (s) if present and is the effective rep rate limit of the beam.',
+    'Current (nA) is a calculated field and is the equivalent maximum electron beam current at the beamclass.',
+    'Power @ 4 GeV (W) is a calculated field and is the equivalent maximum electron beam wattage at 4 GeV at the beamclass.',
+    'Int. Energy @ 4 GeV (J) is a calculated field and is the equivalent maximum integrated electron energy at 4 GeV during the ∆T (s) integration window.',
+    'Notes is an advisory field that gives an example of what this beam class might look like at a particular bunch charge or rep rate.',
+]
 
 
 def get_table_row(row: int) -> list[str]:

--- a/beamclass_table.py
+++ b/beamclass_table.py
@@ -72,16 +72,47 @@ for index, row in enumerate(bc_table):
     bc_table[index] = row.split('\t')
 
 bc_header_full_descriptions = [
-    'Index is the beamclass number. When we say "beamclass 10", we are referring to index 10 on this table.',
-    'Display name is a short, human-readable name that is a minimal description of how the beamclass behaves.',
-    '∆T (s) is the integration time window used for the Q (pC) charge measurement. A beamclass limits the amount of integrated electron charge during a time interval.',
-    'dt (s) is the the minimum bunch spacing (including non-periodic bunch patterns). This effectively limits the rep rate of the beam for periodic bunch patterns.',
-    'Q (pC) is the the maximum beam charge integrated in ∆T (s). A beamclass limits the amount of integrated electron charge during a time interval.',
-    'Rate max (Hz) is a field calculated from dt (s) if present and is the effective rep rate limit of the beam.',
-    'Current (nA) is a calculated field and is the equivalent maximum electron beam current at the beamclass.',
-    'Power @ 4 GeV (W) is a calculated field and is the equivalent maximum electron beam wattage at 4 GeV at the beamclass.',
-    'Int. Energy @ 4 GeV (J) is a calculated field and is the equivalent maximum integrated electron energy at 4 GeV during the ∆T (s) integration window.',
-    'Notes is an advisory field that gives an example of what this beam class might look like at a particular bunch charge or rep rate.',
+    (
+        'Index is the beamclass number. '
+        'When we say "beamclass 10", we are referring to index 10 on this table.'
+    ),
+    (
+        'Display name is a short, human-readable name '
+        'that is a minimal description of how the beamclass behaves.'
+    ),
+    (
+        '∆T (s) is the integration time window used for the Q (pC) charge measurement. '
+        'A beamclass limits the amount of integrated electron charge during a time interval.'
+    ),
+    (
+        'dt (s) is the the minimum bunch spacing (including non-periodic bunch patterns). '
+        'When included, this effectively limits the rep rate of the beam for periodic bunch patterns. '
+        'When omitted, any rep rate could be allowed if it passes the integrated electron charge measurement.'
+    ),
+    (
+        'Q (pC) is the the maximum beam charge integrated in ∆T (s). '
+        'A beamclass limits the amount of integrated electron charge during a time interval.'
+    ),
+    (
+        'Rate max (Hz) is a field calculated from dt (s) if present '
+        'and is the effective rep rate limit of the beam.'
+    ),
+    (
+        'Current (nA) is a calculated field and is the equivalent '
+        'maximum electron beam current at the beamclass.'
+    ),
+    (
+        'Power @ 4 GeV (W) is a calculated field and is the equivalent '
+        'maximum electron beam wattage at 4 GeV at the beamclass.'
+    ),
+    (
+        'Int. Energy @ 4 GeV (J) is a calculated field and is the equivalent '
+        'maximum integrated electron energy at 4 GeV during the ∆T (s) integration window.'
+    ),
+    (
+        'Notes is an advisory field that gives an example of '
+        'what this beam class might look like at a particular bunch charge or rep rate.'
+    ),
 ]
 
 

--- a/beamclass_table.ui
+++ b/beamclass_table.ui
@@ -6,45 +6,143 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>633</width>
+    <height>327</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
-    <widget class="QTableWidget" name="table">
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
-     </property>
-     <property name="rowCount">
-      <number>5</number>
-     </property>
-     <property name="columnCount">
-      <number>5</number>
-     </property>
-     <attribute name="horizontalHeaderVisible">
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
       <bool>true</bool>
-     </attribute>
-     <attribute name="verticalHeaderVisible">
-      <bool>false</bool>
-     </attribute>
-     <row/>
-     <row/>
-     <row/>
-     <row/>
-     <row/>
-     <column/>
-     <column/>
-     <column/>
-     <column/>
-     <column/>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>631</width>
+        <height>325</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QTableWidget" name="table">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="verticalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+         <property name="rowCount">
+          <number>5</number>
+         </property>
+         <property name="columnCount">
+          <number>5</number>
+         </property>
+         <attribute name="horizontalHeaderVisible">
+          <bool>true</bool>
+         </attribute>
+         <attribute name="verticalHeaderVisible">
+          <bool>false</bool>
+         </attribute>
+         <row/>
+         <row/>
+         <row/>
+         <row/>
+         <row/>
+         <column/>
+         <column/>
+         <column/>
+         <column/>
+         <column/>
+        </widget>
+       </item>
+       <item>
+        <widget class="ResizingTextEdit" name="source_links_text">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="verticalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+         <property name="html">
+          <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Version 1.5, released on 12/18/2020, copied into this table on 2/2/2023.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Source: &lt;a href=&quot;https://www-lcls.slac.stanford.edu/web/technotes/LCLS-II-TN-20-12.pdf&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://www-lcls.slac.stanford.edu/web/technotes/LCLS-II-TN-20-12.pdf&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;From the LCLS-II Physics Technical Notes site: &lt;a href=&quot;https://lcls.slac.stanford.edu/technotes&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://lcls.slac.stanford.edu/technotes&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Mouse over any column header for a tooltip explanation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ResizingTextEdit</class>
+   <extends>QTextEdit</extends>
+   <header>widgets</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/line_beam_parameters.py
+++ b/line_beam_parameters.py
@@ -8,8 +8,7 @@ from qtpy import QtCore, QtWidgets
 
 from beamclass_table import bc_table, get_desc_for_bc, install_bc_setText
 from data_bounds import VALID_RATES, get_valid_rate
-from tooltips import (get_ev_range_tooltip, get_tooltip_for_bc,
-                      get_tooltip_for_bc_bitmask)
+from tooltips import get_tooltip_for_bc
 from utils import morph_into_vertical
 
 
@@ -59,8 +58,6 @@ class LineBeamParametersControl(Display):
         self.setup_rate_channel()
         self.setup_bc_bits_connections()
         self.setup_bc_range_channel()
-        self.setup_ev_rbv_channel()
-        self.setup_bc_rbv_channel()
         self.setup_zero_rate()
         self.setup_rate_combo()
         install_bc_setText(self.ui.max_bc_label)
@@ -233,33 +230,6 @@ class LineBeamParametersControl(Display):
             cb.setChecked(bool(status))
         self.update_beamclass_max_from_bitmask(bc_range)
 
-    def setup_ev_rbv_channel(self):
-        prefix = self.config.get('line_arbiter_prefix')
-        self.ev_ranges = None
-        self.last_ev_range = 0
-        ev_definition = PyDMChannel(
-            f'ca://{prefix}eVRangeCnst_RBV',
-            value_slot=self.new_ev_ranges,
-        )
-        ev_definition.connect()
-        self._channels.append(ev_definition)
-        self.ev_range_rbv_channel = PyDMChannel(
-            f'ca://{prefix}BeamParamCntl:ReqBP:PhotonEnergyRanges_RBV',
-            value_slot=self.on_ev_range_rbv_update,
-        )
-        self.ev_range_rbv_channel.connect()
-        self._channels.append(self.ev_range_rbv_channel)
-
-    def setup_bc_rbv_channel(self):
-        prefix = self.config.get('line_arbiter_prefix')
-        ch = f'ca://{prefix}BeamParamCntl:ReqBP:BeamClassRanges_RBV'
-        self.bc_range_rbv_channel = PyDMChannel(
-            ch,
-            value_slot=self.on_bc_range_rbv_update,
-        )
-        self.bc_range_rbv_channel.connect()
-        self._channels.append(self.bc_range_rbv_channel)
-
     def setup_zero_rate(self):
         self.ui.zeroRate.clicked.connect(self.set_zero_rate)
         self.rate_req = None
@@ -383,25 +353,7 @@ class LineBeamParametersControl(Display):
             value = value >> 1
         self.update_beamclass_combobox_value(count)
 
-    def on_ev_range_rbv_update(self, value):
-        self.update_ev_tooltip(value)
-
-    def update_ev_tooltip(self, value=None):
-        if value is None:
-            value = self.last_ev_range
-        else:
-            self.last_ev_range = value
-        if self.ev_ranges is None:
-            return
-        self.ui.ev_rbv_bytes.PyDMToolTip = get_ev_range_tooltip(value, self.ev_ranges)
-
-    def new_ev_ranges(self, value):
-        self.ev_ranges = value
-        self.update_ev_tooltip()
-
     def on_bc_range_rbv_update(self, value):
-        # Update the rbv tooltips
-        self.ui.bc_rbv_bytes.PyDMToolTip = get_tooltip_for_bc_bitmask(value)
         # Update the max bc label
         count = 0
         while value > 0:

--- a/line_beam_parameters.py
+++ b/line_beam_parameters.py
@@ -58,6 +58,7 @@ class LineBeamParametersControl(Display):
         self.setup_rate_channel()
         self.setup_bc_bits_connections()
         self.setup_bc_range_channel()
+        self.setup_bc_rbv_channel()
         self.setup_zero_rate()
         self.setup_rate_combo()
         install_bc_setText(self.ui.max_bc_label)
@@ -249,6 +250,16 @@ class LineBeamParametersControl(Display):
         """
         self.rate_req = value
         self.update_rate_combobox_value(value)
+
+    def setup_bc_rbv_channel(self):
+        prefix = self.config.get('line_arbiter_prefix')
+        ch = f'ca://{prefix}BeamParamCntl:ReqBP:BeamClassRanges_RBV'
+        self.bc_range_rbv_channel = PyDMChannel(
+            ch,
+            value_slot=self.on_bc_range_rbv_update,
+        )
+        self.bc_range_rbv_channel.connect()
+        self._channels.append(self.bc_range_rbv_channel)
 
     def set_zero_rate(self):
         """

--- a/line_beam_parameters.ui
+++ b/line_beam_parameters.ui
@@ -2528,7 +2528,7 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
        <number>4</number>
       </property>
       <item>
-       <widget class="PyDMByteIndicator" name="bc_rbv_bytes">
+       <widget class="BCByteIndicator" name="bc_rbv_bytes">
         <property name="toolTip">
          <string/>
         </property>
@@ -2617,7 +2617,7 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
        <number>4</number>
       </property>
       <item>
-       <widget class="PyDMByteIndicator" name="ev_rbv_bytes">
+       <widget class="EvByteIndicator" name="ev_rbv_bytes">
         <property name="toolTip">
          <string/>
         </property>
@@ -2714,6 +2714,16 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
    <class>PyDMPushButton</class>
    <extends>QPushButton</extends>
    <header>pydm.widgets.pushbutton</header>
+  </customwidget>
+  <customwidget>
+   <class>BCByteIndicator</class>
+   <extends>PyDMByteIndicator</extends>
+   <header>widgets</header>
+  </customwidget>
+  <customwidget>
+   <class>EvByteIndicator</class>
+   <extends>PyDMByteIndicator</extends>
+   <header>widgets</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/pmps.py
+++ b/pmps.py
@@ -13,7 +13,7 @@ from qtpy import QtCore
 from beamclass_table import install_bc_setText
 from tooltips import (get_ev_range_tooltip, get_mode_tooltip_lines,
                       get_tooltip_for_bc, setup_combobox_tooltip)
-from utils import morph_into_vertical
+from utils import BackCompat, morph_into_vertical
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +71,7 @@ class PMPS(Display):
         self.setup_mode_selector()
         self.setup_ev_range_labels()
         self.setup_tooltips()
+        self.setup_backcompat()
         self.setup_tabs()
 
     def setup_mode_selector(self):
@@ -183,6 +184,11 @@ class PMPS(Display):
     def new_ev_ranges(self, value):
         self.ev_ranges = value
         self.update_ev_tooltip()
+
+    def setup_backcompat(self):
+        self.backcompat = BackCompat(parent=self)
+        self.backcompat.add_ev_ranges_alternate(self.ui.ev_req_bytes)
+        self.backcompat.add_ev_ranges_alternate(self.ui.ev_curr_bytes)
 
     def setup_tabs(self):
         # We will do crazy things at this screen... avoid painting

--- a/pmps.ui
+++ b/pmps.ui
@@ -1650,7 +1650,7 @@
              <string/>
             </property>
             <property name="channel" stdset="0">
-             <string>ca://${line_arbiter_prefix}RequestedBP:PhotonEnergyRanges_RBV</string>
+             <string>ca://${line_arbiter_prefix}RequestedBP:eVRanges_RBV</string>
             </property>
             <property name="onColor" stdset="0">
              <color>
@@ -1703,7 +1703,7 @@
            </widget>
           </item>
           <item row="1" column="1" colspan="2">
-           <widget class="PyDMByteIndicator" name="PyDMByteIndicator_2">
+           <widget class="PyDMByteIndicator" name="ev_curr_bytes">
             <property name="enabled">
              <bool>false</bool>
             </property>
@@ -1717,7 +1717,7 @@
              <string/>
             </property>
             <property name="channel" stdset="0">
-             <string>ca://${line_arbiter_prefix}CurrentBP:PhotonEnergyRanges_RBV</string>
+             <string>ca://${line_arbiter_prefix}CurrentBP:eVRanges_RBV</string>
             </property>
             <property name="onColor" stdset="0">
              <color>

--- a/pmps.ui
+++ b/pmps.ui
@@ -586,7 +586,7 @@
         <item>
          <layout class="QGridLayout" name="gridLayout" columnstretch="0,1,1">
           <item row="3" column="1" colspan="2">
-           <widget class="PyDMByteIndicator" name="PyDMByteIndicator_4">
+           <widget class="FixNegBitmaskByteIndicator" name="PyDMByteIndicator_4">
             <property name="enabled">
              <bool>false</bool>
             </property>
@@ -1636,7 +1636,7 @@
            </layout>
           </item>
           <item row="2" column="1" colspan="2">
-           <widget class="PyDMByteIndicator" name="ev_req_bytes">
+           <widget class="EvByteIndicator" name="ev_req_bytes">
             <property name="enabled">
              <bool>false</bool>
             </property>
@@ -1703,7 +1703,7 @@
            </widget>
           </item>
           <item row="1" column="1" colspan="2">
-           <widget class="PyDMByteIndicator" name="ev_curr_bytes">
+           <widget class="EvByteIndicator" name="ev_curr_bytes">
             <property name="enabled">
              <bool>false</bool>
             </property>
@@ -1857,6 +1857,16 @@
    <class>PyDMByteIndicator</class>
    <extends>QWidget</extends>
    <header>pydm.widgets.byte</header>
+  </customwidget>
+  <customwidget>
+   <class>FixNegBitmaskByteIndicator</class>
+   <extends>PyDMByteIndicator</extends>
+   <header>widgets</header>
+  </customwidget>
+  <customwidget>
+   <class>EvByteIndicator</class>
+   <extends>PyDMByteIndicator</extends>
+   <header>widgets</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/preemptive_requests.py
+++ b/preemptive_requests.py
@@ -15,6 +15,7 @@ from beamclass_table import get_max_bc_from_bitmask, install_bc_setText
 from data_bounds import get_valid_rate
 from tooltips import (get_ev_range_tooltip, get_tooltip_for_bc,
                       get_tooltip_for_bc_bitmask)
+from utils import BackCompat
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +81,7 @@ class PreemptiveRequests(Display):
             return
         count = 0
         self.row_logics = []
+        self.backcompat = BackCompat(parent=self)
         for req in reqs:
             prefix = req.get('prefix')
             arbiter = req.get('arbiter_instance')
@@ -126,6 +128,12 @@ class PreemptiveRequests(Display):
                     parent=self,
                 )
                 self._channels.extend(row_logic.pydm_channels)
+
+                row_ev_bytes = widget.findChild(
+                    PyDMByteIndicator,
+                    'energy_bytes',
+                )
+                self.backcompat.add_ev_ranges_alternate(row_ev_bytes)
 
                 # insert the widget you see into the table
                 row_position = reqs_table.rowCount()

--- a/preemptive_requests.py
+++ b/preemptive_requests.py
@@ -5,7 +5,6 @@ import typing
 from dataclasses import dataclass
 from string import Template
 
-import numpy as np
 from pydm import Display
 from pydm.widgets import PyDMByteIndicator, PyDMEmbeddedDisplay, PyDMLabel
 from pydm.widgets.channel import PyDMChannel
@@ -13,8 +12,7 @@ from qtpy import QtCore, QtWidgets
 
 from beamclass_table import get_max_bc_from_bitmask, install_bc_setText
 from data_bounds import get_valid_rate
-from tooltips import (get_ev_range_tooltip, get_tooltip_for_bc,
-                      get_tooltip_for_bc_bitmask)
+from tooltips import get_tooltip_for_bc
 from utils import BackCompat
 
 logger = logging.getLogger(__name__)
@@ -469,62 +467,23 @@ class BCRowLogic(QtCore.QObject):
         install_bc_setText(self.beamclass_label)
 
         # Extra channels for the beamclass bitmask
-        # This lets us put a tooltip stub based on the bitmask
-        # This also lets us update the bc_channel, which is a local
+        # This lets us update the bc_channel, which is a local
         self.beamclass_bytes = row_widget.ui.beamclass_bytes
-        bc_range_channel1 = PyDMChannel(
-            self.beamclass_bytes.channel,
-            value_slot=self.update_bc_bitmask_tooltip,
-        )
-        bc_range_channel1.connect()
-        bc_range_channel2 = PyDMChannel(
+        bc_range_channel = PyDMChannel(
             self.beamclass_bytes.channel,
             value_slot=self.update_max_bc,
         )
-        bc_range_channel2.connect()
+        bc_range_channel.connect()
 
-        # Extra channel for the eV range definition
-        # We need this for the eV bitmask tooltip
-        self.ev_ranges = None
-        self.last_ev_range = 0
-        ev_definition = PyDMChannel(
-            f'ca://{self.line_arbiter_prefix}eVRangeCnst_RBV',
-            value_slot=self.new_ev_ranges,
-        )
-        ev_definition.connect()
-        # Set the eV range tooltip
-        self.ev_bytes = row_widget.ui.energy_bytes
-        ev_range_channel = PyDMChannel(
-            self.ev_bytes.channel,
-            value_slot=self.update_ev_range_tooltip,
-        )
-        ev_range_channel.connect()
-
-        self.pydm_channels = [bc_channel, bc_range_channel1, bc_range_channel2, ev_definition, ev_range_channel]
+        self.pydm_channels = [bc_channel, bc_range_channel]
 
     def update_max_bc(self, value: int):
         self.max_bc_sig.emit(
             get_max_bc_from_bitmask(value)
         )
 
-    def new_ev_ranges(self, value: np.ndarray):
-        self.ev_ranges = value
-        self.update_ev_range_tooltip()
-
     def update_beamclass_tooltip(self, value: int):
         self.beamclass_label.PyDMToolTip = get_tooltip_for_bc(value)
-
-    def update_bc_bitmask_tooltip(self, value: int):
-        self.beamclass_bytes.PyDMToolTip = get_tooltip_for_bc_bitmask(value)
-
-    def update_ev_range_tooltip(self, value=None):
-        if value is None:
-            value = self.last_ev_range
-        else:
-            self.last_ev_range = value
-        if self.ev_ranges is None:
-            return
-        self.ev_bytes.PyDMToolTip = get_ev_range_tooltip(value, self.ev_ranges)
 
 
 @dataclass(frozen=True)

--- a/templates/preemptive_requests_entry.ui
+++ b/templates/preemptive_requests_entry.ui
@@ -300,7 +300,7 @@
       <string/>
      </property>
      <property name="channel" stdset="0">
-      <string>ca://${P}${ARBITER}:AP:Entry:${POOL}:PhotonEnergyRanges_RBV</string>
+      <string>ca://${P}${ARBITER}:AP:Entry:${POOL}:eVRanges_RBV</string>
      </property>
      <property name="onColor" stdset="0">
       <color>

--- a/templates/preemptive_requests_entry.ui
+++ b/templates/preemptive_requests_entry.ui
@@ -101,11 +101,17 @@
      <property name="toolTip">
       <string/>
      </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="indent">
+      <number>50</number>
+     </property>
      <property name="channel" stdset="0">
       <string>ca://${P}${ARBITER}:AP:Entry:${POOL}:ID_RBV</string>
      </property>
      <property name="displayFormat" stdset="0">
-      <enum>PyDMLabel::Hex</enum>
+      <enum>PyDMLabel::Decimal</enum>
      </property>
     </widget>
    </item>

--- a/templates/preemptive_requests_entry.ui
+++ b/templates/preemptive_requests_entry.ui
@@ -181,7 +181,7 @@
     </widget>
    </item>
    <item>
-    <widget class="PyDMByteIndicator" name="beamclass_bytes">
+    <widget class="BCByteIndicator" name="beamclass_bytes">
      <property name="enabled">
       <bool>false</bool>
      </property>
@@ -274,7 +274,7 @@
     </widget>
    </item>
    <item>
-    <widget class="PyDMByteIndicator" name="energy_bytes">
+    <widget class="EvByteIndicator" name="energy_bytes">
      <property name="enabled">
       <bool>false</bool>
      </property>
@@ -422,6 +422,16 @@
    <class>PyDMByteIndicator</class>
    <extends>QWidget</extends>
    <header>pydm.widgets.byte</header>
+  </customwidget>
+  <customwidget>
+   <class>BCByteIndicator</class>
+   <extends>PyDMByteIndicator</extends>
+   <header>widgets</header>
+  </customwidget>
+  <customwidget>
+   <class>EvByteIndicator</class>
+   <extends>PyDMByteIndicator</extends>
+   <header>widgets</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/templates/preemptive_requests_header.ui
+++ b/templates/preemptive_requests_header.ui
@@ -104,7 +104,7 @@
         <string>Assertion ID</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        <set>Qt::AlignCenter</set>
        </property>
       </widget>
      </item>

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,8 @@
+import functools
+from typing import Callable
+
+from pydm.widgets.base import PyDMWidget
+from pydm.widgets.channel import PyDMChannel
 from qtpy import QtCore, QtGui, QtWidgets
 
 
@@ -34,3 +39,107 @@ def morph_into_vertical(label: QtWidgets.QLabel):
     label.sizeHint = sizeHint
     label.paintEvent = paintEvent
     label.update()
+
+
+class BackCompat(QtCore.QObject):
+    """
+    Collector of channels for backwards compatibility.
+
+    This is a class instead of bare functions so we can hold and clean up
+    channels at the end of the process.
+    """
+    def __init__(self, parent=None):
+        super().__init__(parent=parent)
+        # Copy some of the channel handling from PyDM for cleanup
+        # This otherwise requires a full "widget" and is annoying
+        # I'm not 100% sure if this works or not or if that matters
+        self._channels = []
+        self.destroyed.connect(
+            functools.partial(_backcompat_destroyed, self.channels)
+        )
+
+    def channels(self) -> list[PyDMChannel]:
+        """
+        Helper for proper channel cleanup.
+        """
+        return self._channels()
+
+    def add_alternate_channel(self, widget: PyDMWidget, channel: str) -> None:
+        """
+        Add an alternate channel for the widget.
+
+        When the alternate channel connects, it will be assigned to the widget
+        instead of the widget's original chanenl.
+
+        This is intended to be used for PV name changes so that either name will work.
+
+        Parameters
+        ----------
+        widget : PyDMWidget
+            A widget that has a singular "channel" property that holds the channel
+            address that can be updated.
+        channel : str
+            A channel address to use as the alternate channel.
+        """
+        # Assign the alt channel somewhere so it doesn't get garbage collected
+        ch = PyDMChannel(
+            address=channel,
+            connection_slot=functools.partial(
+                self.apply_alt_channel,
+                widget=widget,
+                channel=channel,
+            ),
+        )
+        ch.connect()
+        self._channels.append(ch)
+
+    def apply_alt_channel(
+        self,
+        connected: bool,
+        widget: PyDMWidget,
+        channel: str,
+    ) -> None:
+        """
+        Connection callback for updating a widget's default channel.
+
+        This will be called when the alternate channel connects.
+
+        Parameters
+        ----------
+        connected : bool
+            Boolean from the connection_state_signal that lets us know if
+            the alternate channel is connected.
+        widget : PyDMWidget
+            Widget to update
+        channel : str
+            Alternate channel to apply.
+        """
+        if connected and widget.channel != channel:
+            widget.channel = channel
+
+    def add_ev_ranges_alternate(self, widget: PyDMWidget) -> None:
+        """
+        Handle the evRanges PV name change.
+
+        Currently, some IOCs are using "PhotonEnergyRanges" and the
+        newer IOCs are using "eVRanges" to appropriately shorten the PV names.
+
+        The .ui files have been updated to use "eVRanges" and this function
+        will use add_alternate_channel for backwards compatibility
+        until we've updated every IOC.
+        """
+        return self.add_alternate_channel(
+            widget=widget,
+            channel=widget.channel.replace("eVRanges", "PhotonEnergyRanges")
+        )
+
+
+def _backcompat_destroyed(channels: Callable[[], list[PyDMChannel]]) -> None:
+    """
+    Some cleanup stolen from PyDM
+
+    See PyDM.widgets.base.widget_destroyed
+    """
+    for ch in channels():
+        if ch:
+            ch.disconnect(destroying=True)

--- a/widgets.py
+++ b/widgets.py
@@ -484,3 +484,36 @@ class EvByteIndicator(ValueTooltipByteIndicator):
         self._range_def = list(range_def)
         if isinstance(self.value, int):
             self.PyDMToolTip = self.tooltip_function(self.value)
+
+
+class ResizingTextEdit(QtWidgets.QTextEdit):
+    """
+    A QTextEdit that resizes it's height to match its contents.
+    """
+    def set_height_to_text(self) -> None:
+        """
+        Set the height to match the current height of the enclosed text.
+        """
+        self.setFixedHeight(
+            self.document().size().toSize().height()
+        )
+
+    def showEvent(self, ev: QtGui.QShowEvent) -> None:
+        """
+        On show, set the height appropriately.
+
+        This handles the case where we switch to a tab with this
+        widget included.
+        """
+        self.set_height_to_text()
+        return super().showEvent(ev)
+
+    def resizeEvent(self, ev: QtGui.QResizeEvent) -> None:
+        """
+        On resize, set the height appropriately.
+
+        This handles the case where we resize the widget to the point
+        that the line wrap increases or decreases the text height.
+        """
+        self.set_height_to_text()
+        return super().resizeEvent(ev)


### PR DESCRIPTION
- PV name needed to change because it was too long (limit 60 chars)
- Some IOCs are updated, some are not
- I want the ui to work regardless, so let's make both versions work

This ended up having some cascading buggy behavior. The best way to resolve this was to refactor and clean up a lot of the eV range handling, doing it via widget promotion instead of by ad-hoc function applications.

Later, I was asked to make some adjustments to the beamclass table in the PMPS WG meeting e.g. citing the source and adding table header tooltips.