### PR TITLE
FIX/ENH: KFE configs

### DIFF
--- a/KFE_config.yml
+++ b/KFE_config.yml
@@ -94,6 +94,11 @@ preemptive_requests:
     assertion_pool_start: 1
     assertion_pool_end: 20
 
+  - prefix: "PLC:KFE:VAC:K0:"
+    arbiter_instance: "Arb:01"
+    assertion_pool_start: 1
+    assertion_pool_end: 20
+
   - prefix: "PLC:KFE:GATT:"
     arbiter_instance: "ARB:01"
     assertion_pool_start: 1

--- a/KFE_config.yml
+++ b/KFE_config.yml
@@ -39,7 +39,7 @@ fastfaults:
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
-    ff_end: 55
+    ff_end: 100
 
   - prefix: "PLC:KFE:MOTION:"
     ffo_start: 1

--- a/KFE_config.yml
+++ b/KFE_config.yml
@@ -39,7 +39,7 @@ fastfaults:
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
-    ff_end: 100
+    ff_end: 200
 
   - prefix: "PLC:KFE:MOTION:"
     ffo_start: 1


### PR DESCRIPTION
- tmo motion is configured for 200 FFs now (currently has 89, will soon eclipse 100)
- KFE vac PLC was entirely missing from the pre-emptive section

I don't know who I should be asking to review PRs like these