### PR TITLE
ENH: transmission override ui elements

### DIFF
--- a/KFE_config.yml
+++ b/KFE_config.yml
@@ -1,6 +1,8 @@
 line_arbiter_prefix: "PMPS:KFE:"
 undulator_kicker_rate_pv: "IOC:BSY0:MP01:BYKIKS_RATE"
 accelerator_mode_pv: "SIOC:FEES:MP01:FACMODE_RBV"
+trans_req_pv: "AT1K0:GAS:TRANS_REQ_RBV"
+trans_rbv_pv: "AT1K0:GAS:TRANS_RBV"
 
 dashboard_url: "http://ctl-logsrv01:3000/ctl/grafana/d/PRr2cuGGz/k-pmps-events?viewPanel=2&orgId=1&refresh=10s&kiosk"
 

--- a/LFE_config.yml
+++ b/LFE_config.yml
@@ -1,6 +1,8 @@
 line_arbiter_prefix: "PMPS:LFE:"
 undulator_kicker_rate_pv: "IOC:BSY0:MP01:BYKIK_RATE"
 accelerator_mode_pv: "SIOC:FEEH:MP01:FACMODE_RBV"
+trans_req_pv: "PMPS:LFE:RequestedBP:Transmission_RBV"
+trans_rbv_pv: "PMPS:LFE:CurrentBP:Transmission_RBV"
 
 dashboard_url: "http://ctl-logsrv01:3000/ctl/grafana/d/PQBzCnmMz/l-pmps-events?refresh=10s&kiosk"
 

--- a/TST_config.yml
+++ b/TST_config.yml
@@ -1,6 +1,8 @@
 line_arbiter_prefix: "PMPS:TST:"
 undulator_kicker_rate_pv: "PMPS:TST:BYKIK_RATE"
 accelerator_mode_pv: "PMPS:TST:LCLSMODE_RBV"
+trans_req_pv: "AT1K0:GAS:TRANS_REQ_RBV"
+trans_rbv_pv: "AT1K0:GAS:TRANS_RBV"
 
 dashboard_url: "about:new"
 

--- a/grafana_log_display.py
+++ b/grafana_log_display.py
@@ -16,7 +16,7 @@ class GrafanaLogDisplay(Display):
         self.ui.btn_open_browser.clicked.connect(self.handle_open_browser)
 
     def open_webpage_if_tab(self, tab_index):
-        if tab_index == 7 and not self.web_open:
+        if tab_index == 8 and not self.web_open:
             self.ui.webbrowser.load(QtCore.QUrl(self.dash_url))
             self.web_open = True
         elif self.web_open:

--- a/line_beam_parameters.py
+++ b/line_beam_parameters.py
@@ -38,6 +38,9 @@ class LineBeamParametersControl(Display):
     # Signal to set a new beamclass from the combobox or from zero rate button
     update_beamclass_signal = QtCore.Signal(int)
 
+    # Signal to set a new transmission, adjusted by the jf
+    new_transmission_signal = QtCore.Signal(float)
+
     def __init__(self, parent=None, args=None, macros=None):
         super().__init__(parent=parent, args=args, macros=macros)
         self.config = macros
@@ -64,6 +67,7 @@ class LineBeamParametersControl(Display):
         install_bc_setText(self.ui.max_bc_label)
         self.setup_beamclass_combo()
         self.rate_channel.connect()
+        self.setup_transmission_jf()
 
     def setup_bits_connections(self):
         """
@@ -372,3 +376,72 @@ class LineBeamParametersControl(Display):
             value = value >> 1
         self.ui.max_bc_label.setText(str(count))
         self.ui.max_bc_label.setToolTip(get_tooltip_for_bc(count))
+
+    def setup_transmission_jf(self):
+        line_arbiter_prefix = self.config.get('line_arbiter_prefix')
+        if line_arbiter_prefix is None:
+            return
+        # Values to use prior to various PV connections
+        self.cached_transmission_rbv = 1
+        self.cached_jf_setting = 5
+        self.cached_jf_on_off = False
+        # If we emit from self.new_transmission_signal, put to the real PV
+        self.trans_set_channel = PyDMChannel(
+            f"ca://{line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission",
+            value_signal=self.new_transmission_signal,
+        )
+        # We get inputs from the user via a local channel
+        # I do this to take advantage of PyDMLineEdit's input handling
+        self.gui_trans_set_channel = PyDMChannel(
+            "loc://trans_set",
+            value_slot=self.gui_trans_set,
+        )
+        # If we get a new value, show the scaled value
+        self.trans_get_channel = PyDMChannel(
+            f"ca://{line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission_RBV",
+            value_slot=self.new_trans_value,
+        )
+        # If we get a new JF, cache it and show the scaled value
+        self.new_jf_channel = PyDMChannel(
+            f"ca://{line_arbiter_prefix}IntensityJF_RBV",
+            value_slot=self.new_jf_value,
+        )
+        # If JF starts/expires, cache it and show the scaled value
+        self.jf_on_off_channel = PyDMChannel(
+            f"ca://{line_arbiter_prefix}ApplyJF_RBV",
+            value_slot=self.new_jf_on_off,
+        )
+        self.trans_set_channel.connect()
+        self.trans_get_channel.connect()
+        self.new_jf_channel.connect()
+        self.jf_on_off_channel.connect()
+        self._channels.append(self.trans_set_channel)
+        self._channels.append(self.trans_get_channel)
+        self._channels.append(self.new_jf_channel)
+        self._channels.append(self.jf_on_off_channel)
+
+    def new_trans_value(self, value):
+        self.cached_transmission_rbv = value
+        self.update_trans_rbv()
+
+    def new_jf_value(self, value):
+        self.cached_jf_setting = value
+        self.update_trans_rbv()
+
+    def new_jf_on_off(self, value):
+        self.cached_jf_on_off = value
+        self.update_trans_rbv()
+
+    def get_jf(self):
+        if self.cached_jf_on_off:
+            return self.cached_jf_setting or 5
+        else:
+            return 5
+
+    def update_trans_rbv(self):
+        value = min(self.cached_transmission_rbv * 5 / self.get_jf(), 1)
+        self.ui.trans_get.setText(f"{value:.2e}")
+
+    def gui_trans_set(self, value):
+        setpoint = value * self.get_jf() / 5
+        self.new_transmission_signal.emit(setpoint)

--- a/line_beam_parameters.py
+++ b/line_beam_parameters.py
@@ -378,8 +378,9 @@ class LineBeamParametersControl(Display):
         self.ui.max_bc_label.setToolTip(get_tooltip_for_bc(count))
 
     def setup_transmission_jf(self):
-        line_arbiter_prefix = self.config.get('line_arbiter_prefix')
-        if line_arbiter_prefix is None:
+        try:
+            line_arbiter_prefix = self.config["line_arbiter_prefix"]
+        except KeyError:
             return
         # Values to use prior to various PV connections
         self.cached_transmission_rbv = 1

--- a/line_beam_parameters.py
+++ b/line_beam_parameters.py
@@ -393,7 +393,7 @@ class LineBeamParametersControl(Display):
         # We get inputs from the user via a local channel
         # I do this to take advantage of PyDMLineEdit's input handling
         self.gui_trans_set_channel = PyDMChannel(
-            "loc://trans_set",
+            "loc://trans_set?type=float&init=1&precision=2",
             value_slot=self.gui_trans_set,
         )
         # If we get a new value, show the scaled value
@@ -412,10 +412,12 @@ class LineBeamParametersControl(Display):
             value_slot=self.new_jf_on_off,
         )
         self.trans_set_channel.connect()
+        self.gui_trans_set_channel.connect()
         self.trans_get_channel.connect()
         self.new_jf_channel.connect()
         self.jf_on_off_channel.connect()
         self._channels.append(self.trans_set_channel)
+        self._channels.append(self.gui_trans_set_channel)
         self._channels.append(self.trans_get_channel)
         self._channels.append(self.new_jf_channel)
         self._channels.append(self.jf_on_off_channel)

--- a/line_beam_parameters.ui
+++ b/line_beam_parameters.ui
@@ -126,7 +126,7 @@
    <item row="6" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_10">
      <item>
-      <widget class="PyDMPushButton" name="applyButton_2">
+      <widget class="PyDMPushButton" name="jf_cancel">
        <property name="enabled">
         <bool>false</bool>
        </property>
@@ -193,7 +193,7 @@
       </widget>
      </item>
      <item>
-      <widget class="PyDMPushButton" name="applyButton_3">
+      <widget class="PyDMPushButton" name="jf_apply">
        <property name="enabled">
         <bool>false</bool>
        </property>
@@ -1654,7 +1654,7 @@ and Zero BC</string>
       <number>0</number>
      </property>
      <item>
-      <widget class="PyDMLabel" name="PyDMLabel_4">
+      <widget class="PyDMLabel" name="jf_duration">
        <property name="minimumSize">
         <size>
          <width>50</width>
@@ -1735,7 +1735,7 @@ and Zero BC</string>
       </spacer>
      </item>
      <item>
-      <widget class="PyDMLineEdit" name="PyDMLineEdit_3">
+      <widget class="PyDMLineEdit" name="jf_duration_set">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -2258,7 +2258,7 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       <number>0</number>
      </property>
      <item>
-      <widget class="PyDMLabel" name="PyDMLabel_2">
+      <widget class="PyDMLabel" name="jf_cred_energy">
        <property name="minimumSize">
         <size>
          <width>50</width>
@@ -2339,7 +2339,7 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       </spacer>
      </item>
      <item>
-      <widget class="PyDMLineEdit" name="PyDMLineEdit">
+      <widget class="PyDMLineEdit" name="jf_cred_energy_set">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -3147,7 +3147,7 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
    <item row="4" column="2">
     <layout class="QHBoxLayout" name="horizontalLayout_11">
      <item>
-      <widget class="PyDMByteIndicator" name="JFActiveByte">
+      <widget class="PyDMByteIndicator" name="jf_active_byte">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -3204,7 +3204,7 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       </widget>
      </item>
      <item>
-      <widget class="PyDMLabel" name="PyDMLabel_5">
+      <widget class="PyDMLabel" name="jf_time_remaining">
        <property name="minimumSize">
         <size>
          <width>50</width>

--- a/line_beam_parameters.ui
+++ b/line_beam_parameters.ui
@@ -3389,7 +3389,7 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       <string/>
      </property>
      <property name="channel" stdset="0">
-      <string>loc://trans_set?type=float&amp;init=1&amp;precision=2</string>
+      <string>loc://trans_set</string>
      </property>
      <property name="displayFormat" stdset="0">
       <enum>PyDMLineEdit::Exponential</enum>

--- a/line_beam_parameters.ui
+++ b/line_beam_parameters.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>884</width>
-    <height>782</height>
+    <height>630</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -888,16 +888,6 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      <property name="text">
       <string>Zero Rate
 and Zero BC</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="PyDMLabel" name="PyDMLabel">
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission_RBV</string>
      </property>
     </widget>
    </item>
@@ -3169,43 +3159,6 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </layout>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="PyDMLineEdit" name="transEdit">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>100</width>
-       <height>26</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>200</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="precision" stdset="0">
-      <number>2</number>
-     </property>
-     <property name="showUnits" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="precisionFromPV" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission</string>
-     </property>
-     <property name="displayFormat" stdset="0">
-      <enum>PyDMLineEdit::Exponential</enum>
-     </property>
-    </widget>
-   </item>
    <item row="33" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_10">
      <item>
@@ -3390,6 +3343,56 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </property>
      <property name="text">
       <string>Transmission Override</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLabel" name="trans_get">
+     <property name="text">
+      <string>Loading...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="PyDMLineEdit" name="PyDMLineEdit">
+     <property name="minimumSize">
+      <size>
+       <width>200</width>
+       <height>23</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>23</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="precision" stdset="0">
+      <number>2</number>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="precisionFromPV" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="PyDMToolTip" stdset="0">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>loc://trans_set?type=float&amp;init=1&amp;precision=2</string>
+     </property>
+     <property name="displayFormat" stdset="0">
+      <enum>PyDMLineEdit::Exponential</enum>
      </property>
     </widget>
    </item>

--- a/line_beam_parameters.ui
+++ b/line_beam_parameters.ui
@@ -7,1508 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>884</width>
-    <height>630</height>
+    <height>667</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="26" column="0" colspan="3">
-    <widget class="Line" name="line_3">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="25" column="0">
-    <widget class="QLabel" name="label_28">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Click this button to apply the transmission, photon energy ranges, rate, and beamclass that are defined above.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Apply All Parameters Above:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_30">
-     <property name="font">
-      <font>
-       <pointsize>12</pointsize>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use this section to apply limits for maximum beam parameters. For example, we can set the maximum allowed transmission, add a constraint to the eV ranges, or set limits on beam rate or beam class that are more strict than the active beamline elements.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Beam Parameters</string>
-     </property>
-    </widget>
-   </item>
-   <item row="17" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="PyDMLabel" name="PyDMLabel_3">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Rate_RBV</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_17">
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>Hz</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="13" column="1" colspan="2">
-    <widget class="QFrame" name="frame_2">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>30</height>
-      </size>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::Panel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_4">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <property name="leftMargin">
-       <number>4</number>
-      </property>
-      <property name="topMargin">
-       <number>4</number>
-      </property>
-      <property name="rightMargin">
-       <number>4</number>
-      </property>
-      <property name="bottomMargin">
-       <number>4</number>
-      </property>
-      <item>
-       <widget class="EvByteIndicator" name="ev_rbv_bytes">
-        <property name="toolTip">
-         <string/>
-        </property>
-        <property name="alarmSensitiveContent" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="alarmSensitiveBorder" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="PyDMToolTip" stdset="0">
-         <string/>
-        </property>
-        <property name="channel" stdset="0">
-         <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:PhotonEnergyRanges_RBV</string>
-        </property>
-        <property name="orientation" stdset="0">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="showLabels" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="bigEndian" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="circles" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="numBits" stdset="0">
-         <number>32</number>
-        </property>
-        <property name="shift" stdset="0">
-         <number>0</number>
-        </property>
-        <property name="labels" stdset="0">
-         <stringlist>
-          <string>Bit 0</string>
-          <string>Bit 1</string>
-          <string>Bit 2</string>
-          <string>Bit 3</string>
-          <string>Bit 4</string>
-          <string>Bit 5</string>
-          <string>Bit 6</string>
-          <string>Bit 7</string>
-          <string>Bit 8</string>
-          <string>Bit 9</string>
-          <string>Bit 10</string>
-          <string>Bit 11</string>
-          <string>Bit 12</string>
-          <string>Bit 13</string>
-          <string>Bit 14</string>
-          <string>Bit 15</string>
-          <string>Bit 16</string>
-          <string>Bit 17</string>
-          <string>Bit 18</string>
-          <string>Bit 19</string>
-          <string>Bit 20</string>
-          <string>Bit 21</string>
-          <string>Bit 22</string>
-          <string>Bit 23</string>
-          <string>Bit 24</string>
-          <string>Bit 25</string>
-          <string>Bit 26</string>
-          <string>Bit 27</string>
-          <string>Bit 28</string>
-          <string>Bit 29</string>
-          <string>Bit 30</string>
-          <string>Bit 31</string>
-         </stringlist>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="14" column="0">
-    <widget class="QLabel" name="label_13">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the selector for eV ranges.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Photon Energy Range Select:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="14" column="1" colspan="2">
-    <widget class="QFrame" name="energy_range_frame">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>26</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="layoutDirection">
-      <enum>Qt::LeftToRight</enum>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::Panel</enum>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <property name="leftMargin">
-       <number>6</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QCheckBox" name="bit31">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit30">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit29">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit28">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit27">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit26">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit25">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit24">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit23">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit22">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit21">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit20">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit19">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit18">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit17">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit16">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit15">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit14">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit13">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit12">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit11">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit10">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit9">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit8">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit7">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit6">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit5">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit4">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit3">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit2">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit1">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit0">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_11">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the setpoint for the transmission selection. Type in a number and then press &amp;quot;Enter&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Transmission Select:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="19" column="1">
-    <widget class="QFrame" name="frame">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>30</height>
-      </size>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::Panel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_8">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <property name="leftMargin">
-       <number>4</number>
-      </property>
-      <property name="topMargin">
-       <number>4</number>
-      </property>
-      <property name="rightMargin">
-       <number>4</number>
-      </property>
-      <property name="bottomMargin">
-       <number>4</number>
-      </property>
-      <item>
-       <widget class="BCByteIndicator" name="bc_rbv_bytes">
-        <property name="toolTip">
-         <string/>
-        </property>
-        <property name="alarmSensitiveContent" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="alarmSensitiveBorder" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="PyDMToolTip" stdset="0">
-         <string/>
-        </property>
-        <property name="channel" stdset="0">
-         <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:BeamClassRanges_RBV</string>
-        </property>
-        <property name="orientation" stdset="0">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="showLabels" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="bigEndian" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="circles" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="numBits" stdset="0">
-         <number>15</number>
-        </property>
-        <property name="shift" stdset="0">
-         <number>0</number>
-        </property>
-        <property name="labels" stdset="0">
-         <stringlist>
-          <string>Bit 0</string>
-          <string>Bit 1</string>
-          <string>Bit 2</string>
-          <string>Bit 3</string>
-          <string>Bit 4</string>
-          <string>Bit 5</string>
-          <string>Bit 6</string>
-          <string>Bit 7</string>
-          <string>Bit 8</string>
-          <string>Bit 9</string>
-          <string>Bit 10</string>
-          <string>Bit 11</string>
-          <string>Bit 12</string>
-          <string>Bit 13</string>
-          <string>Bit 14</string>
-         </stringlist>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="17" column="2" rowspan="7">
-    <widget class="QPushButton" name="zeroRate">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>150</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>150</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This button will immediately set the beam parameters to a &amp;quot;no beam&amp;quot; state and send the apply signal.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">background-color: rgb(255, 85, 85);</string>
-     </property>
-     <property name="text">
-      <string>Zero Rate
-and Zero BC</string>
-     </property>
-    </widget>
-   </item>
-   <item row="18" column="0">
-    <widget class="QLabel" name="label_15">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the input for selecting which maximum NC rate to use.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Rate Select [NC]:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="23" column="0">
-    <widget class="QLabel" name="label_19">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is a simplified selector that allows you to to pick the highest allowed beamclass and also allow all beamclasses at lower levels.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Beamclass Simple Select [SC]:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="32" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_9">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="PyDMLabel" name="jf_duration">
-       <property name="minimumSize">
-        <size>
-         <width>50</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>50</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="precision" stdset="0">
-        <number>2</number>
-       </property>
-       <property name="showUnits" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}DurationJF_RBV</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_25">
-       <property name="minimumSize">
-        <size>
-         <width>25</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>25</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>hrs</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_4">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>130</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="PyDMLineEdit" name="jf_duration_set">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>200</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="precision" stdset="0">
-        <number>2</number>
-       </property>
-       <property name="showUnits" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}DurationJF</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="31" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_5">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="PyDMLabel" name="jf_cred_energy">
-       <property name="minimumSize">
-        <size>
-         <width>50</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>50</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="showUnits" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}IntensityJF_RBV</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_26">
-       <property name="minimumSize">
-        <size>
-         <width>25</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>25</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>mJ</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>130</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="PyDMLineEdit" name="jf_cred_energy_set">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>200</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="showUnits" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}IntensityJF</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="25" column="1">
-    <widget class="PyDMPushButton" name="applyButton">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>100</width>
-       <height>26</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>200</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">background-color: rgb(148, 255, 85);</string>
-     </property>
-     <property name="text">
-      <string>Apply</string>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Apply</string>
-     </property>
-     <property name="showConfirmDialog" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="pressValue" stdset="0">
-      <string>1</string>
-     </property>
-    </widget>
-   </item>
-   <item row="22" column="0">
-    <widget class="QLabel" name="label_18">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is a user-readable summary of the selected beamclass range: simply the highest-level beamclass that will be allowed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Requested Max [SC]:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_12">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the maximum transmission constraint that will be applied.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Requested Transmission :</string>
-     </property>
-    </widget>
-   </item>
-   <item row="14" column="3">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="34" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="22" column="1">
-    <widget class="QLabel" name="max_bc_label">
-     <property name="text">
-      <string>Loading...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="21" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_7">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <property name="leftMargin">
-      <number>4</number>
-     </property>
-     <property name="rightMargin">
-      <number>4</number>
-     </property>
-     <item>
-      <widget class="QLabel" name="label_bit14_2">
-       <property name="text">
-        <string>15</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit13_2">
-       <property name="text">
-        <string>14</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit12_2">
-       <property name="text">
-        <string>13</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit11_2">
-       <property name="text">
-        <string>12</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit10_2">
-       <property name="text">
-        <string>11</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit9_2">
-       <property name="text">
-        <string>10</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit8_2">
-       <property name="text">
-        <string>9</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit7_2">
-       <property name="text">
-        <string>8</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit6_2">
-       <property name="text">
-        <string>7</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit5_2">
-       <property name="text">
-        <string>6</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit4_2">
-       <property name="text">
-        <string>5</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit3_2">
-       <property name="text">
-        <string>4</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit2_2">
-       <property name="text">
-        <string>3</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit1_2">
-       <property name="text">
-        <string>2</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit0_2">
-       <property name="text">
-        <string>1</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="16" column="0" colspan="3">
-    <widget class="Line" name="line_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="33" column="0">
-    <widget class="QLabel" name="label_24">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Click &amp;quot;apply&amp;quot; to start the transmission override mode. Click &amp;quot;cancel&amp;quot; to return to the normal protection mode.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Apply Transmission Override:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="28" column="0">
-    <spacer name="horizontalSpacer_5">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="24" column="0" colspan="3">
-    <widget class="Line" name="line_4">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="3">
-    <widget class="Line" name="line_7">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
    <item row="15" column="3">
     <spacer name="horizontalSpacer_2">
      <property name="orientation">
@@ -1522,181 +27,10 @@ and Zero BC</string>
      </property>
     </spacer>
    </item>
-   <item row="19" column="0">
-    <widget class="QLabel" name="label_20">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;These are the allowed beamclasses that will be applied.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Beamclass Ranges [SC]:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="31" column="2">
-    <layout class="QHBoxLayout" name="horizontalLayout_11">
-     <item>
-      <widget class="PyDMByteIndicator" name="jf_active_byte">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>26</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>26</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}ApplyJF_RBV</string>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="bigEndian" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="numBits" stdset="0">
-        <number>1</number>
-       </property>
-       <property name="shift" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="labels" stdset="0">
-        <stringlist>
-         <string>Bit 0</string>
-        </stringlist>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="jf_time_remaining">
-       <property name="minimumSize">
-        <size>
-         <width>50</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>50</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="precision" stdset="0">
-        <number>2</number>
-       </property>
-       <property name="showUnits" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}TimeRemainJF_RBV</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_27">
-       <property name="maximumSize">
-        <size>
-         <width>125</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <weight>50</weight>
-         <bold>false</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>hrs remaining</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="18" column="1">
-    <widget class="QComboBox" name="rateComboBox">
-     <property name="maximumSize">
-      <size>
-       <width>200</width>
-       <height>16777215</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="31" column="0">
-    <widget class="QLabel" name="label_22">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Readback and setpoint for the maximum credible energy in the context of a transmission override. If this is 5mJ, then we will use the maximum transmission protections. If this is set to lower than 5mJ and applied, then we will adjust all transmission protections proportionally.&lt;/p&gt;&lt;p&gt;Note that if we already have a transmission override applied, adjusting this parameter further will update the protection threshold, live.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Maximum Credible Energy:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="0">
-    <widget class="QLabel" name="label_14">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;These are the eV ranges that will be allowed after we apply.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Photon Energy Ranges:</string>
+   <item row="24" column="0" colspan="3">
+    <widget class="Line" name="line_4">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
@@ -2840,22 +1174,8 @@ and Zero BC</string>
      </item>
     </layout>
    </item>
-   <item row="30" column="0" colspan="3">
-    <widget class="Line" name="line_6">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="0" colspan="3">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="20" column="0">
-    <widget class="QLabel" name="label_21">
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_11">
      <property name="font">
       <font>
        <weight>75</weight>
@@ -2863,12 +1183,125 @@ and Zero BC</string>
       </font>
      </property>
      <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the bit-by-bit selector for allowed beam classes.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the setpoint for the transmission selection. Type in a number and then press &amp;quot;Enter&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
-      <string>Beamclass Range Select [SC]:</string>
+      <string>Transmission Select:</string>
      </property>
     </widget>
+   </item>
+   <item row="29" column="0" colspan="3">
+    <widget class="Line" name="line_5">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="26" column="0" colspan="3">
+    <widget class="Line" name="line_3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="17" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="PyDMLabel" name="PyDMLabel_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Rate_RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_17">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Hz</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="22" column="0">
+    <widget class="QLabel" name="label_18">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is a user-readable summary of the selected beamclass range: simply the highest-level beamclass that will be allowed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Requested Max [SC]:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="25" column="1">
+    <widget class="PyDMPushButton" name="applyButton">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>26</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QPushButton { background-color: rgb(148, 255, 85) }</string>
+     </property>
+     <property name="text">
+      <string>Apply</string>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Apply</string>
+     </property>
+     <property name="showConfirmDialog" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="pressValue" stdset="0">
+      <string>1</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="3">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item row="23" column="1">
     <widget class="QComboBox" name="beamclassComboBox">
@@ -2879,6 +1312,36 @@ and Zero BC</string>
       </size>
      </property>
     </widget>
+   </item>
+   <item row="22" column="1">
+    <widget class="QLabel" name="max_bc_label">
+     <property name="text">
+      <string>Loading...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="0" colspan="3">
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="27" column="0">
+    <spacer name="horizontalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item row="20" column="1">
     <widget class="QFrame" name="energy_range_frame_2">
@@ -3159,143 +1622,642 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </layout>
     </widget>
    </item>
-   <item row="33" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_10">
-     <item>
-      <widget class="PyDMPushButton" name="jf_cancel">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>200</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">background-color: rgb(255, 85, 85);</string>
-       </property>
-       <property name="text">
-        <string>Cancel</string>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}CancelJF</string>
-       </property>
-       <property name="passwordProtected" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="password" stdset="0">
-        <string/>
-       </property>
-       <property name="protectedPassword" stdset="0">
-        <string/>
-       </property>
-       <property name="showConfirmDialog" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="confirmMessage" stdset="0">
-        <string>Are you sure you want to proceed?</string>
-       </property>
-       <property name="pressValue" stdset="0">
-        <string>1</string>
-       </property>
-       <property name="releaseValue" stdset="0">
-        <string>None</string>
-       </property>
-       <property name="relativeChange" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="writeWhenRelease" stdset="0">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMPushButton" name="jf_apply">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>200</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">background-color: rgb(148, 255, 85);</string>
-       </property>
-       <property name="text">
-        <string>Apply</string>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}ApplyJF</string>
-       </property>
-       <property name="passwordProtected" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="password" stdset="0">
-        <string/>
-       </property>
-       <property name="protectedPassword" stdset="0">
-        <string/>
-       </property>
-       <property name="showConfirmDialog" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="confirmMessage" stdset="0">
-        <string>Are you sure you want to proceed?</string>
-       </property>
-       <property name="pressValue" stdset="0">
-        <string>1</string>
-       </property>
-       <property name="releaseValue" stdset="0">
-        <string>None</string>
-       </property>
-       <property name="relativeChange" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="writeWhenRelease" stdset="0">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="14" column="1" colspan="2">
+    <widget class="QFrame" name="energy_range_frame">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>26</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="layoutDirection">
+      <enum>Qt::LeftToRight</enum>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Panel</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QCheckBox" name="bit31">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit30">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit29">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit28">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit27">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit26">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit25">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit24">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit23">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit22">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit21">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit20">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit19">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit18">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit17">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit16">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit15">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit14">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit13">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit12">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit11">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit10">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit9">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit8">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit7">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit6">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit5">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit4">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit3">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit1">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit0">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_30">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use this section to apply limits for maximum beam parameters. For example, we can set the maximum allowed transmission, add a constraint to the eV ranges, or set limits on beam rate or beam class that are more strict than the active beamline elements.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Beam Parameters</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="0">
+    <widget class="QLabel" name="label_13">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the selector for eV ranges.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Photon Energy Range Select:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="3">
+    <widget class="Line" name="line_7">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="19" column="0">
+    <widget class="QLabel" name="label_20">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;These are the allowed beamclasses that will be applied.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Beamclass Ranges [SC]:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLabel" name="trans_get">
+     <property name="text">
+      <string>Loading...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0" colspan="3">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="23" column="0">
+    <widget class="QLabel" name="label_19">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is a simplified selector that allows you to to pick the highest allowed beamclass and also allow all beamclasses at lower levels.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Beamclass Simple Select [SC]:</string>
+     </property>
+    </widget>
    </item>
    <item row="17" column="0">
     <widget class="QLabel" name="label_16">
@@ -3313,8 +2275,8 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </property>
     </widget>
    </item>
-   <item row="32" column="0">
-    <widget class="QLabel" name="label_23">
+   <item row="13" column="0">
+    <widget class="QLabel" name="label_14">
      <property name="font">
       <font>
        <weight>75</weight>
@@ -3322,34 +2284,10 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       </font>
      </property>
      <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the timeout after which we will remove our transmission override. It is intended to be overridden for the length of a single shift.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;These are the eV ranges that will be allowed after we apply.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
-      <string>Duration/Timeout:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="29" column="0">
-    <widget class="QLabel" name="label_29">
-     <property name="font">
-      <font>
-       <pointsize>12</pointsize>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use this section to globally relax the transmission requirements. The transmission requirements are designed to protect us from a 5mJ beam. If your beam is substantially weaker than 5mJ, you can put in the maximum credible energy here to temporarily adjust all of the transmission protections to compensate.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Transmission Override</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLabel" name="trans_get">
-     <property name="text">
-      <string>Loading...</string>
+      <string>Photon Energy Ranges:</string>
      </property>
     </widget>
    </item>
@@ -3371,7 +2309,7 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
       <string/>
      </property>
      <property name="precision" stdset="0">
-      <number>2</number>
+      <number>0</number>
      </property>
      <property name="showUnits" stdset="0">
       <bool>false</bool>
@@ -3393,6 +2331,513 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </property>
      <property name="displayFormat" stdset="0">
       <enum>PyDMLineEdit::Exponential</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="19" column="1">
+    <widget class="QFrame" name="frame">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Panel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_8">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
+      <item>
+       <widget class="BCByteIndicator" name="bc_rbv_bytes">
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="alarmSensitiveContent" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="alarmSensitiveBorder" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="PyDMToolTip" stdset="0">
+         <string/>
+        </property>
+        <property name="channel" stdset="0">
+         <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:BeamClassRanges_RBV</string>
+        </property>
+        <property name="orientation" stdset="0">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="showLabels" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="bigEndian" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="circles" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="numBits" stdset="0">
+         <number>15</number>
+        </property>
+        <property name="shift" stdset="0">
+         <number>0</number>
+        </property>
+        <property name="labels" stdset="0">
+         <stringlist>
+          <string>Bit 0</string>
+          <string>Bit 1</string>
+          <string>Bit 2</string>
+          <string>Bit 3</string>
+          <string>Bit 4</string>
+          <string>Bit 5</string>
+          <string>Bit 6</string>
+          <string>Bit 7</string>
+          <string>Bit 8</string>
+          <string>Bit 9</string>
+          <string>Bit 10</string>
+          <string>Bit 11</string>
+          <string>Bit 12</string>
+          <string>Bit 13</string>
+          <string>Bit 14</string>
+         </stringlist>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="21" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_7">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="leftMargin">
+      <number>4</number>
+     </property>
+     <property name="rightMargin">
+      <number>4</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label_bit14_2">
+       <property name="text">
+        <string>15</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit13_2">
+       <property name="text">
+        <string>14</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit12_2">
+       <property name="text">
+        <string>13</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit11_2">
+       <property name="text">
+        <string>12</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit10_2">
+       <property name="text">
+        <string>11</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit9_2">
+       <property name="text">
+        <string>10</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit8_2">
+       <property name="text">
+        <string>9</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit7_2">
+       <property name="text">
+        <string>8</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit6_2">
+       <property name="text">
+        <string>7</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit5_2">
+       <property name="text">
+        <string>6</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit4_2">
+       <property name="text">
+        <string>5</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit3_2">
+       <property name="text">
+        <string>4</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit2_2">
+       <property name="text">
+        <string>3</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit1_2">
+       <property name="text">
+        <string>2</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit0_2">
+       <property name="text">
+        <string>1</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="18" column="0">
+    <widget class="QLabel" name="label_15">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the input for selecting which maximum NC rate to use.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Rate Select [NC]:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_12">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the maximum transmission constraint that will be applied.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Requested Transmission :</string>
+     </property>
+    </widget>
+   </item>
+   <item row="31" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="13" column="1" colspan="2">
+    <widget class="QFrame" name="frame_2">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Panel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
+      <item>
+       <widget class="EvByteIndicator" name="ev_rbv_bytes">
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="alarmSensitiveContent" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="alarmSensitiveBorder" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="PyDMToolTip" stdset="0">
+         <string/>
+        </property>
+        <property name="channel" stdset="0">
+         <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:PhotonEnergyRanges_RBV</string>
+        </property>
+        <property name="orientation" stdset="0">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="showLabels" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="bigEndian" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="circles" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="numBits" stdset="0">
+         <number>32</number>
+        </property>
+        <property name="shift" stdset="0">
+         <number>0</number>
+        </property>
+        <property name="labels" stdset="0">
+         <stringlist>
+          <string>Bit 0</string>
+          <string>Bit 1</string>
+          <string>Bit 2</string>
+          <string>Bit 3</string>
+          <string>Bit 4</string>
+          <string>Bit 5</string>
+          <string>Bit 6</string>
+          <string>Bit 7</string>
+          <string>Bit 8</string>
+          <string>Bit 9</string>
+          <string>Bit 10</string>
+          <string>Bit 11</string>
+          <string>Bit 12</string>
+          <string>Bit 13</string>
+          <string>Bit 14</string>
+          <string>Bit 15</string>
+          <string>Bit 16</string>
+          <string>Bit 17</string>
+          <string>Bit 18</string>
+          <string>Bit 19</string>
+          <string>Bit 20</string>
+          <string>Bit 21</string>
+          <string>Bit 22</string>
+          <string>Bit 23</string>
+          <string>Bit 24</string>
+          <string>Bit 25</string>
+          <string>Bit 26</string>
+          <string>Bit 27</string>
+          <string>Bit 28</string>
+          <string>Bit 29</string>
+          <string>Bit 30</string>
+          <string>Bit 31</string>
+         </stringlist>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="17" column="2" rowspan="7">
+    <widget class="QPushButton" name="zeroRate">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>150</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>150</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This button will immediately set the beam parameters to a &amp;quot;no beam&amp;quot; state and send the apply signal.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QPushButton { background-color: rgb(255, 85, 85) }</string>
+     </property>
+     <property name="text">
+      <string>Zero Rate
+and Zero BC</string>
+     </property>
+    </widget>
+   </item>
+   <item row="20" column="0">
+    <widget class="QLabel" name="label_21">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the bit-by-bit selector for allowed beam classes.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Beamclass Range Select [SC]:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="18" column="1">
+    <widget class="QComboBox" name="rateComboBox">
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="25" column="0">
+    <widget class="QLabel" name="label_28">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Click this button to apply the transmission, photon energy ranges, rate, and beamclass that are defined above.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Apply All Parameters:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="28" column="0">
+    <widget class="QLabel" name="label_31">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>Usage Notes</string>
+     </property>
+    </widget>
+   </item>
+   <item row="30" column="0" colspan="3">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>- The beam parameters applied above act as additional constraints on the beam.
+  These cannot be used to override any specific device's PMPS protections.
+
+- Some of these parameters only apply in NC mode or only in SC mode.
+  This is denoted by the [NC] and [SC] tags above.
+
+- The current active parameters from this tab are logged as the &quot;BP Control Device&quot; in the preemptive requests tab.</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::AutoText</enum>
+     </property>
+     <property name="wordWrap">
+      <bool>false</bool>
      </property>
     </widget>
    </item>
@@ -3420,12 +2865,12 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
    <header>pydm.widgets.pushbutton</header>
   </customwidget>
   <customwidget>
-   <class>BCByteIndicator</class>
+   <class>EvByteIndicator</class>
    <extends>PyDMByteIndicator</extends>
    <header>widgets</header>
   </customwidget>
   <customwidget>
-   <class>EvByteIndicator</class>
+   <class>BCByteIndicator</class>
    <extends>PyDMByteIndicator</extends>
    <header>widgets</header>
   </customwidget>

--- a/line_beam_parameters.ui
+++ b/line_beam_parameters.ui
@@ -7,15 +7,15 @@
     <x>0</x>
     <y>0</y>
     <width>896</width>
-    <height>416</height>
+    <height>662</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="7" column="0">
-    <widget class="QLabel" name="label_16">
+   <item row="12" column="0">
+    <widget class="QLabel" name="label_13">
      <property name="font">
       <font>
        <weight>75</weight>
@@ -23,300 +23,11 @@
       </font>
      </property>
      <property name="text">
-      <string>Requested Rate [NC]:</string>
+      <string>Photon Energy Range Select:</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="1">
-    <widget class="QFrame" name="energy_range_frame_2">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>26</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="layoutDirection">
-      <enum>Qt::LeftToRight</enum>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::Panel</enum>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_3">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <property name="leftMargin">
-       <number>6</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QCheckBox" name="bit14_2">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit13_2">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit12_2">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit11_2">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit10_2">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit9_2">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit8_2">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit7_2">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit6_2">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit5_2">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit4_2">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit3_2">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit2_2">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit1_2">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit0_2">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="PyDMLabel" name="PyDMLabel">
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission_RBV</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0">
+   <item row="18" column="0">
     <widget class="QLabel" name="label_21">
      <property name="font">
       <font>
@@ -330,19 +41,412 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
     </widget>
    </item>
    <item row="15" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="PyDMLabel" name="PyDMLabel_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Rate_RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_17">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Hz</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="11" column="0">
+    <widget class="QLabel" name="label_14">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
      </property>
-     <property name="sizeHint" stdset="0">
+     <property name="text">
+      <string>Photon Energy Ranges:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="22" column="1">
+    <widget class="PyDMPushButton" name="applyButton">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
       <size>
-       <width>20</width>
-       <height>40</height>
+       <width>100</width>
+       <height>26</height>
       </size>
      </property>
-    </spacer>
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">background-color: rgb(148, 255, 85);</string>
+     </property>
+     <property name="text">
+      <string>Apply</string>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Apply</string>
+     </property>
+     <property name="showConfirmDialog" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="pressValue" stdset="0">
+      <string>1</string>
+     </property>
+    </widget>
    </item>
-   <item row="7" column="2" rowspan="8">
+   <item row="6" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_10">
+     <item>
+      <widget class="PyDMPushButton" name="applyButton_2">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>200</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: rgb(255, 85, 85);</string>
+       </property>
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}CancelJF</string>
+       </property>
+       <property name="passwordProtected" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="password" stdset="0">
+        <string/>
+       </property>
+       <property name="protectedPassword" stdset="0">
+        <string/>
+       </property>
+       <property name="showConfirmDialog" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="confirmMessage" stdset="0">
+        <string>Are you sure you want to proceed?</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+       <property name="releaseValue" stdset="0">
+        <string>None</string>
+       </property>
+       <property name="relativeChange" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="writeWhenRelease" stdset="0">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMPushButton" name="applyButton_3">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>200</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: rgb(148, 255, 85);</string>
+       </property>
+       <property name="text">
+        <string>Apply</string>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}ApplyJF</string>
+       </property>
+       <property name="passwordProtected" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="password" stdset="0">
+        <string/>
+       </property>
+       <property name="protectedPassword" stdset="0">
+        <string/>
+       </property>
+       <property name="showConfirmDialog" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="confirmMessage" stdset="0">
+        <string>Are you sure you want to proceed?</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+       <property name="releaseValue" stdset="0">
+        <string>None</string>
+       </property>
+       <property name="relativeChange" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="writeWhenRelease" stdset="0">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="20" column="0">
+    <widget class="QLabel" name="label_18">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Requested Max [SC]:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="21" column="0">
+    <widget class="QLabel" name="label_19">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Beamclass Simple Select [SC]:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_12">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Requested Transmission :</string>
+     </property>
+    </widget>
+   </item>
+   <item row="20" column="1">
+    <widget class="QLabel" name="max_bc_label">
+     <property name="text">
+      <string>Loading...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="17" column="1">
+    <widget class="QFrame" name="frame">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Panel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_8">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
+      <item>
+       <widget class="BCByteIndicator" name="bc_rbv_bytes">
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="alarmSensitiveContent" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="alarmSensitiveBorder" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="PyDMToolTip" stdset="0">
+         <string/>
+        </property>
+        <property name="channel" stdset="0">
+         <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:BeamClassRanges_RBV</string>
+        </property>
+        <property name="orientation" stdset="0">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="showLabels" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="bigEndian" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="circles" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="numBits" stdset="0">
+         <number>15</number>
+        </property>
+        <property name="shift" stdset="0">
+         <number>0</number>
+        </property>
+        <property name="labels" stdset="0">
+         <stringlist>
+          <string>Bit 0</string>
+          <string>Bit 1</string>
+          <string>Bit 2</string>
+          <string>Bit 3</string>
+          <string>Bit 4</string>
+          <string>Bit 5</string>
+          <string>Bit 6</string>
+          <string>Bit 7</string>
+          <string>Bit 8</string>
+          <string>Bit 9</string>
+          <string>Bit 10</string>
+          <string>Bit 11</string>
+          <string>Bit 12</string>
+          <string>Bit 13</string>
+          <string>Bit 14</string>
+         </stringlist>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="16" column="1">
+    <widget class="QComboBox" name="rateComboBox">
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0" colspan="3">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_24">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Apply Transmission Override:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="0" colspan="3">
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_11">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Transmission Select:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="2" rowspan="8">
     <widget class="QPushButton" name="zeroRate">
      <property name="minimumSize">
       <size>
@@ -365,232 +469,8 @@ and Zero BC</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="PyDMLineEdit" name="transEdit">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>100</width>
-       <height>26</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>200</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="precision" stdset="0">
-      <number>2</number>
-     </property>
-     <property name="showUnits" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="precisionFromPV" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission</string>
-     </property>
-     <property name="displayFormat" stdset="0">
-      <enum>PyDMLineEdit::Exponential</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="3">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="1">
-    <widget class="QComboBox" name="beamclassComboBox">
-     <property name="maximumSize">
-      <size>
-       <width>200</width>
-       <height>16777215</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="1">
-    <widget class="QLabel" name="max_bc_label">
-     <property name="text">
-      <string>Loading...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_7">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <property name="leftMargin">
-      <number>4</number>
-     </property>
-     <property name="rightMargin">
-      <number>4</number>
-     </property>
-     <item>
-      <widget class="QLabel" name="label_bit14_2">
-       <property name="text">
-        <string>15</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit13_2">
-       <property name="text">
-        <string>14</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit12_2">
-       <property name="text">
-        <string>13</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit11_2">
-       <property name="text">
-        <string>12</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit10_2">
-       <property name="text">
-        <string>11</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit9_2">
-       <property name="text">
-        <string>10</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit8_2">
-       <property name="text">
-        <string>9</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit7_2">
-       <property name="text">
-        <string>8</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit6_2">
-       <property name="text">
-        <string>7</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit5_2">
-       <property name="text">
-        <string>6</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit4_2">
-       <property name="text">
-        <string>5</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit3_2">
-       <property name="text">
-        <string>4</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit2_2">
-       <property name="text">
-        <string>3</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit1_2">
-       <property name="text">
-        <string>2</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit0_2">
-       <property name="text">
-        <string>1</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_13">
+   <item row="16" column="0">
+    <widget class="QLabel" name="label_15">
      <property name="font">
       <font>
        <weight>75</weight>
@@ -598,24 +478,11 @@ and Zero BC</string>
       </font>
      </property>
      <property name="text">
-      <string>Photon Energy Range Select:</string>
+      <string>Rate Select [NC]:</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="label_20">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Beamclass Ranges [SC]:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1" colspan="2">
+   <item row="13" column="1" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout_6">
      <property name="spacing">
       <number>0</number>
@@ -1755,8 +1622,8 @@ and Zero BC</string>
      </item>
     </layout>
    </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="label_15">
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_23">
      <property name="font">
       <font>
        <weight>75</weight>
@@ -1764,24 +1631,11 @@ and Zero BC</string>
       </font>
      </property>
      <property name="text">
-      <string>Rate Select [NC]:</string>
+      <string>Duration/Timeout:</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_12">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Requested Transmission :</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="3">
+   <item row="12" column="3">
     <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -1794,43 +1648,151 @@ and Zero BC</string>
      </property>
     </spacer>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_11">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
+   <item row="5" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_9">
+     <property name="spacing">
+      <number>0</number>
      </property>
-     <property name="text">
-      <string>Transmission Select:</string>
+     <item>
+      <widget class="PyDMLabel" name="PyDMLabel_4">
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>50</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>2</number>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}DurationJF_RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_25">
+       <property name="minimumSize">
+        <size>
+         <width>25</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>25</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>hrs</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>130</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>200</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>2</number>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}DurationJF</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="0" column="1">
+    <widget class="PyDMLabel" name="PyDMLabel">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission_RBV</string>
      </property>
     </widget>
    </item>
-   <item row="13" column="0">
-    <widget class="QLabel" name="label_19">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Beamclass Simple Select [SC]:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1">
-    <widget class="QComboBox" name="rateComboBox">
-     <property name="maximumSize">
-      <size>
-       <width>200</width>
-       <height>16777215</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="3">
+   <item row="13" column="3">
     <spacer name="horizontalSpacer_2">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -1843,51 +1805,588 @@ and Zero BC</string>
      </property>
     </spacer>
    </item>
-   <item row="6" column="0" colspan="3">
-    <widget class="Line" name="line_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="15" column="0">
+    <widget class="QLabel" name="label_16">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Requested Rate [NC]:</string>
      </property>
     </widget>
    </item>
-   <item row="14" column="1">
-    <widget class="PyDMPushButton" name="applyButton">
-     <property name="enabled">
-      <bool>false</bool>
+   <item row="26" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-     <property name="minimumSize">
+     <property name="sizeHint" stdset="0">
       <size>
-       <width>100</width>
-       <height>26</height>
+       <width>20</width>
+       <height>40</height>
       </size>
      </property>
+    </spacer>
+   </item>
+   <item row="17" column="0">
+    <widget class="QLabel" name="label_20">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Beamclass Ranges [SC]:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="21" column="1">
+    <widget class="QComboBox" name="beamclassComboBox">
      <property name="maximumSize">
       <size>
        <width>200</width>
        <height>16777215</height>
       </size>
      </property>
-     <property name="toolTip">
-      <string/>
+    </widget>
+   </item>
+   <item row="11" column="1" colspan="2">
+    <widget class="QFrame" name="frame_2">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>30</height>
+      </size>
      </property>
-     <property name="styleSheet">
-      <string notr="true">background-color: rgb(148, 255, 85);</string>
+     <property name="frameShape">
+      <enum>QFrame::Panel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
+      <item>
+       <widget class="EvByteIndicator" name="ev_rbv_bytes">
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="alarmSensitiveContent" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="alarmSensitiveBorder" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="PyDMToolTip" stdset="0">
+         <string/>
+        </property>
+        <property name="channel" stdset="0">
+         <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:PhotonEnergyRanges_RBV</string>
+        </property>
+        <property name="orientation" stdset="0">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="showLabels" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="bigEndian" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="circles" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="numBits" stdset="0">
+         <number>32</number>
+        </property>
+        <property name="shift" stdset="0">
+         <number>0</number>
+        </property>
+        <property name="labels" stdset="0">
+         <stringlist>
+          <string>Bit 0</string>
+          <string>Bit 1</string>
+          <string>Bit 2</string>
+          <string>Bit 3</string>
+          <string>Bit 4</string>
+          <string>Bit 5</string>
+          <string>Bit 6</string>
+          <string>Bit 7</string>
+          <string>Bit 8</string>
+          <string>Bit 9</string>
+          <string>Bit 10</string>
+          <string>Bit 11</string>
+          <string>Bit 12</string>
+          <string>Bit 13</string>
+          <string>Bit 14</string>
+          <string>Bit 15</string>
+          <string>Bit 16</string>
+          <string>Bit 17</string>
+          <string>Bit 18</string>
+          <string>Bit 19</string>
+          <string>Bit 20</string>
+          <string>Bit 21</string>
+          <string>Bit 22</string>
+          <string>Bit 23</string>
+          <string>Bit 24</string>
+          <string>Bit 25</string>
+          <string>Bit 26</string>
+          <string>Bit 27</string>
+          <string>Bit 28</string>
+          <string>Bit 29</string>
+          <string>Bit 30</string>
+          <string>Bit 31</string>
+         </stringlist>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="18" column="1">
+    <widget class="QFrame" name="energy_range_frame_2">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>26</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="layoutDirection">
+      <enum>Qt::LeftToRight</enum>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Panel</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QCheckBox" name="bit14_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit13_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit12_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit11_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit10_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit9_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit8_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit7_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit6_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit5_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit4_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit3_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit2_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit1_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit0_2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_22">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
      </property>
      <property name="text">
-      <string>Apply</string>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Apply</string>
-     </property>
-     <property name="showConfirmDialog" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="pressValue" stdset="0">
-      <string>1</string>
+      <string>Maximum Credible Energy:</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1" colspan="2">
+   <item row="4" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="PyDMLabel" name="PyDMLabel_2">
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>50</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}IntensityJF_RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_26">
+       <property name="minimumSize">
+        <size>
+         <width>25</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>25</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>mJ</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>130</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="PyDMLineEdit" name="PyDMLineEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>200</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}IntensityJF</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="12" column="1" colspan="2">
     <widget class="QFrame" name="energy_range_frame">
      <property name="minimumSize">
       <size>
@@ -2438,259 +2937,332 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </layout>
     </widget>
    </item>
-   <item row="12" column="0">
-    <widget class="QLabel" name="label_18">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
+   <item row="1" column="1">
+    <widget class="PyDMLineEdit" name="transEdit">
+     <property name="enabled">
+      <bool>false</bool>
      </property>
-     <property name="text">
-      <string>Requested Max [SC]:</string>
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>26</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="precision" stdset="0">
+      <number>2</number>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="precisionFromPV" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission</string>
+     </property>
+     <property name="displayFormat" stdset="0">
+      <enum>PyDMLineEdit::Exponential</enum>
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout">
+   <item row="3" column="0" colspan="3">
+    <widget class="Line" name="line_3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="19" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_7">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="leftMargin">
+      <number>4</number>
+     </property>
+     <property name="rightMargin">
+      <number>4</number>
+     </property>
      <item>
-      <widget class="PyDMLabel" name="PyDMLabel_3">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
+      <widget class="QLabel" name="label_bit14_2">
+       <property name="text">
+        <string>15</string>
        </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Rate_RBV</string>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_17">
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
+      <widget class="QLabel" name="label_bit13_2">
        <property name="text">
-        <string>Hz</string>
+        <string>14</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit12_2">
+       <property name="text">
+        <string>13</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit11_2">
+       <property name="text">
+        <string>12</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit10_2">
+       <property name="text">
+        <string>11</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit9_2">
+       <property name="text">
+        <string>10</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit8_2">
+       <property name="text">
+        <string>9</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit7_2">
+       <property name="text">
+        <string>8</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit6_2">
+       <property name="text">
+        <string>7</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit5_2">
+       <property name="text">
+        <string>6</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit4_2">
+       <property name="text">
+        <string>5</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit3_2">
+       <property name="text">
+        <string>4</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit2_2">
+       <property name="text">
+        <string>3</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit1_2">
+       <property name="text">
+        <string>2</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit0_2">
+       <property name="text">
+        <string>1</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
        </property>
       </widget>
      </item>
     </layout>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_14">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Photon Energy Ranges:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1">
-    <widget class="QFrame" name="frame">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>30</height>
-      </size>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::Panel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_8">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <property name="leftMargin">
-       <number>4</number>
-      </property>
-      <property name="topMargin">
-       <number>4</number>
-      </property>
-      <property name="rightMargin">
-       <number>4</number>
-      </property>
-      <property name="bottomMargin">
-       <number>4</number>
-      </property>
-      <item>
-       <widget class="BCByteIndicator" name="bc_rbv_bytes">
-        <property name="toolTip">
-         <string/>
-        </property>
-        <property name="alarmSensitiveContent" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="alarmSensitiveBorder" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="PyDMToolTip" stdset="0">
-         <string/>
-        </property>
-        <property name="channel" stdset="0">
-         <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:BeamClassRanges_RBV</string>
-        </property>
-        <property name="orientation" stdset="0">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="showLabels" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="bigEndian" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="circles" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="numBits" stdset="0">
-         <number>15</number>
-        </property>
-        <property name="shift" stdset="0">
-         <number>0</number>
-        </property>
-        <property name="labels" stdset="0">
-         <stringlist>
-          <string>Bit 0</string>
-          <string>Bit 1</string>
-          <string>Bit 2</string>
-          <string>Bit 3</string>
-          <string>Bit 4</string>
-          <string>Bit 5</string>
-          <string>Bit 6</string>
-          <string>Bit 7</string>
-          <string>Bit 8</string>
-          <string>Bit 9</string>
-          <string>Bit 10</string>
-          <string>Bit 11</string>
-          <string>Bit 12</string>
-          <string>Bit 13</string>
-          <string>Bit 14</string>
-         </stringlist>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="3" column="1" colspan="2">
-    <widget class="QFrame" name="frame_2">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>30</height>
-      </size>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::Panel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_4">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <property name="leftMargin">
-       <number>4</number>
-      </property>
-      <property name="topMargin">
-       <number>4</number>
-      </property>
-      <property name="rightMargin">
-       <number>4</number>
-      </property>
-      <property name="bottomMargin">
-       <number>4</number>
-      </property>
-      <item>
-       <widget class="EvByteIndicator" name="ev_rbv_bytes">
-        <property name="toolTip">
-         <string/>
-        </property>
-        <property name="alarmSensitiveContent" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="alarmSensitiveBorder" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="PyDMToolTip" stdset="0">
-         <string/>
-        </property>
-        <property name="channel" stdset="0">
-         <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:PhotonEnergyRanges_RBV</string>
-        </property>
-        <property name="orientation" stdset="0">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="showLabels" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="bigEndian" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="circles" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="numBits" stdset="0">
-         <number>32</number>
-        </property>
-        <property name="shift" stdset="0">
-         <number>0</number>
-        </property>
-        <property name="labels" stdset="0">
-         <stringlist>
-          <string>Bit 0</string>
-          <string>Bit 1</string>
-          <string>Bit 2</string>
-          <string>Bit 3</string>
-          <string>Bit 4</string>
-          <string>Bit 5</string>
-          <string>Bit 6</string>
-          <string>Bit 7</string>
-          <string>Bit 8</string>
-          <string>Bit 9</string>
-          <string>Bit 10</string>
-          <string>Bit 11</string>
-          <string>Bit 12</string>
-          <string>Bit 13</string>
-          <string>Bit 14</string>
-          <string>Bit 15</string>
-          <string>Bit 16</string>
-          <string>Bit 17</string>
-          <string>Bit 18</string>
-          <string>Bit 19</string>
-          <string>Bit 20</string>
-          <string>Bit 21</string>
-          <string>Bit 22</string>
-          <string>Bit 23</string>
-          <string>Bit 24</string>
-          <string>Bit 25</string>
-          <string>Bit 26</string>
-          <string>Bit 27</string>
-          <string>Bit 28</string>
-          <string>Bit 29</string>
-          <string>Bit 30</string>
-          <string>Bit 31</string>
-         </stringlist>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+   <item row="4" column="2">
+    <layout class="QHBoxLayout" name="horizontalLayout_11">
+     <item>
+      <widget class="PyDMByteIndicator" name="JFActiveByte">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>26</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>26</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}ApplyJF_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="PyDMLabel_5">
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>50</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>2</number>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}TimeRemainJF_RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_27">
+       <property name="maximumSize">
+        <size>
+         <width>125</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <weight>50</weight>
+         <bold>false</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>hrs remaining</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/line_beam_parameters.ui
+++ b/line_beam_parameters.ui
@@ -6,41 +6,55 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>896</width>
-    <height>662</height>
+    <width>884</width>
+    <height>782</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="12" column="0">
-    <widget class="QLabel" name="label_13">
+   <item row="26" column="0" colspan="3">
+    <widget class="Line" name="line_3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="25" column="0">
+    <widget class="QLabel" name="label_28">
      <property name="font">
       <font>
        <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Click this button to apply the transmission, photon energy ranges, rate, and beamclass that are defined above.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
      <property name="text">
-      <string>Photon Energy Range Select:</string>
+      <string>Apply All Parameters Above:</string>
      </property>
     </widget>
    </item>
-   <item row="18" column="0">
-    <widget class="QLabel" name="label_21">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_30">
      <property name="font">
       <font>
+       <pointsize>12</pointsize>
        <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use this section to apply limits for maximum beam parameters. For example, we can set the maximum allowed transmission, add a constraint to the eV ranges, or set limits on beam rate or beam class that are more strict than the active beamline elements.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
      <property name="text">
-      <string>Beamclass Range Select [SC]:</string>
+      <string>Beam Parameters</string>
      </property>
     </widget>
    </item>
-   <item row="15" column="1">
+   <item row="17" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="PyDMLabel" name="PyDMLabel_3">
@@ -73,241 +87,696 @@
      </item>
     </layout>
    </item>
-   <item row="11" column="0">
-    <widget class="QLabel" name="label_14">
+   <item row="13" column="1" colspan="2">
+    <widget class="QFrame" name="frame_2">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Panel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
+      <item>
+       <widget class="EvByteIndicator" name="ev_rbv_bytes">
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="alarmSensitiveContent" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="alarmSensitiveBorder" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="PyDMToolTip" stdset="0">
+         <string/>
+        </property>
+        <property name="channel" stdset="0">
+         <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:PhotonEnergyRanges_RBV</string>
+        </property>
+        <property name="orientation" stdset="0">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="showLabels" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="bigEndian" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="circles" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="numBits" stdset="0">
+         <number>32</number>
+        </property>
+        <property name="shift" stdset="0">
+         <number>0</number>
+        </property>
+        <property name="labels" stdset="0">
+         <stringlist>
+          <string>Bit 0</string>
+          <string>Bit 1</string>
+          <string>Bit 2</string>
+          <string>Bit 3</string>
+          <string>Bit 4</string>
+          <string>Bit 5</string>
+          <string>Bit 6</string>
+          <string>Bit 7</string>
+          <string>Bit 8</string>
+          <string>Bit 9</string>
+          <string>Bit 10</string>
+          <string>Bit 11</string>
+          <string>Bit 12</string>
+          <string>Bit 13</string>
+          <string>Bit 14</string>
+          <string>Bit 15</string>
+          <string>Bit 16</string>
+          <string>Bit 17</string>
+          <string>Bit 18</string>
+          <string>Bit 19</string>
+          <string>Bit 20</string>
+          <string>Bit 21</string>
+          <string>Bit 22</string>
+          <string>Bit 23</string>
+          <string>Bit 24</string>
+          <string>Bit 25</string>
+          <string>Bit 26</string>
+          <string>Bit 27</string>
+          <string>Bit 28</string>
+          <string>Bit 29</string>
+          <string>Bit 30</string>
+          <string>Bit 31</string>
+         </stringlist>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="14" column="0">
+    <widget class="QLabel" name="label_13">
      <property name="font">
       <font>
        <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the selector for eV ranges.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
      <property name="text">
-      <string>Photon Energy Ranges:</string>
+      <string>Photon Energy Range Select:</string>
      </property>
     </widget>
    </item>
-   <item row="22" column="1">
-    <widget class="PyDMPushButton" name="applyButton">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
+   <item row="14" column="1" colspan="2">
+    <widget class="QFrame" name="energy_range_frame">
      <property name="minimumSize">
       <size>
-       <width>100</width>
+       <width>0</width>
        <height>26</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>200</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
+     <property name="layoutDirection">
+      <enum>Qt::LeftToRight</enum>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Panel</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QCheckBox" name="bit31">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit30">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit29">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit28">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit27">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit26">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit25">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit24">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit23">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit22">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit21">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit20">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit19">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit18">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit17">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit16">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit15">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit14">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit13">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit12">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit11">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit10">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit9">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit8">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit7">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit6">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit5">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit4">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit3">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit2">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit1">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bit0">
+        <property name="styleSheet">
+         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
+QCheckBox::indicator::checked {background-color: green;}
+QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
+QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_11">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
      <property name="toolTip">
-      <string/>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">background-color: rgb(148, 255, 85);</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the setpoint for the transmission selection. Type in a number and then press &amp;quot;Enter&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
-      <string>Apply</string>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Apply</string>
-     </property>
-     <property name="showConfirmDialog" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="pressValue" stdset="0">
-      <string>1</string>
+      <string>Transmission Select:</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_10">
-     <item>
-      <widget class="PyDMPushButton" name="jf_cancel">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>200</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">background-color: rgb(255, 85, 85);</string>
-       </property>
-       <property name="text">
-        <string>Cancel</string>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}CancelJF</string>
-       </property>
-       <property name="passwordProtected" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="password" stdset="0">
-        <string/>
-       </property>
-       <property name="protectedPassword" stdset="0">
-        <string/>
-       </property>
-       <property name="showConfirmDialog" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="confirmMessage" stdset="0">
-        <string>Are you sure you want to proceed?</string>
-       </property>
-       <property name="pressValue" stdset="0">
-        <string>1</string>
-       </property>
-       <property name="releaseValue" stdset="0">
-        <string>None</string>
-       </property>
-       <property name="relativeChange" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="writeWhenRelease" stdset="0">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMPushButton" name="jf_apply">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>200</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">background-color: rgb(148, 255, 85);</string>
-       </property>
-       <property name="text">
-        <string>Apply</string>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}ApplyJF</string>
-       </property>
-       <property name="passwordProtected" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="password" stdset="0">
-        <string/>
-       </property>
-       <property name="protectedPassword" stdset="0">
-        <string/>
-       </property>
-       <property name="showConfirmDialog" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="confirmMessage" stdset="0">
-        <string>Are you sure you want to proceed?</string>
-       </property>
-       <property name="pressValue" stdset="0">
-        <string>1</string>
-       </property>
-       <property name="releaseValue" stdset="0">
-        <string>None</string>
-       </property>
-       <property name="relativeChange" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="writeWhenRelease" stdset="0">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="20" column="0">
-    <widget class="QLabel" name="label_18">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Requested Max [SC]:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="21" column="0">
-    <widget class="QLabel" name="label_19">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Beamclass Simple Select [SC]:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_12">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Requested Transmission :</string>
-     </property>
-    </widget>
-   </item>
-   <item row="20" column="1">
-    <widget class="QLabel" name="max_bc_label">
-     <property name="text">
-      <string>Loading...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="17" column="1">
+   <item row="19" column="1">
     <widget class="QFrame" name="frame">
      <property name="minimumSize">
       <size>
@@ -396,57 +865,7 @@
      </layout>
     </widget>
    </item>
-   <item row="16" column="1">
-    <widget class="QComboBox" name="rateComboBox">
-     <property name="maximumSize">
-      <size>
-       <width>200</width>
-       <height>16777215</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0" colspan="3">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label_24">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Apply Transmission Override:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="14" column="0" colspan="3">
-    <widget class="Line" name="line_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_11">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Transmission Select:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="2" rowspan="8">
+   <item row="17" column="2" rowspan="7">
     <widget class="QPushButton" name="zeroRate">
      <property name="minimumSize">
       <size>
@@ -460,6 +879,9 @@
        <height>150</height>
       </size>
      </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This button will immediately set the beam parameters to a &amp;quot;no beam&amp;quot; state and send the apply signal.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
      <property name="styleSheet">
       <string notr="true">background-color: rgb(255, 85, 85);</string>
      </property>
@@ -469,7 +891,17 @@ and Zero BC</string>
      </property>
     </widget>
    </item>
-   <item row="16" column="0">
+   <item row="2" column="1">
+    <widget class="PyDMLabel" name="PyDMLabel">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission_RBV</string>
+     </property>
+    </widget>
+   </item>
+   <item row="18" column="0">
     <widget class="QLabel" name="label_15">
      <property name="font">
       <font>
@@ -477,12 +909,808 @@ and Zero BC</string>
        <bold>true</bold>
       </font>
      </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the input for selecting which maximum NC rate to use.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
      <property name="text">
       <string>Rate Select [NC]:</string>
      </property>
     </widget>
    </item>
-   <item row="13" column="1" colspan="2">
+   <item row="23" column="0">
+    <widget class="QLabel" name="label_19">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is a simplified selector that allows you to to pick the highest allowed beamclass and also allow all beamclasses at lower levels.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Beamclass Simple Select [SC]:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="32" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_9">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="PyDMLabel" name="jf_duration">
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>50</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>2</number>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}DurationJF_RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_25">
+       <property name="minimumSize">
+        <size>
+         <width>25</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>25</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>hrs</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>130</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="PyDMLineEdit" name="jf_duration_set">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>200</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>2</number>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}DurationJF</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="31" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="PyDMLabel" name="jf_cred_energy">
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>50</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}IntensityJF_RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_26">
+       <property name="minimumSize">
+        <size>
+         <width>25</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>25</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>mJ</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>130</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="PyDMLineEdit" name="jf_cred_energy_set">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>200</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}IntensityJF</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="25" column="1">
+    <widget class="PyDMPushButton" name="applyButton">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>26</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">background-color: rgb(148, 255, 85);</string>
+     </property>
+     <property name="text">
+      <string>Apply</string>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Apply</string>
+     </property>
+     <property name="showConfirmDialog" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="pressValue" stdset="0">
+      <string>1</string>
+     </property>
+    </widget>
+   </item>
+   <item row="22" column="0">
+    <widget class="QLabel" name="label_18">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is a user-readable summary of the selected beamclass range: simply the highest-level beamclass that will be allowed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Requested Max [SC]:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_12">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the maximum transmission constraint that will be applied.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Requested Transmission :</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="3">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="34" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="22" column="1">
+    <widget class="QLabel" name="max_bc_label">
+     <property name="text">
+      <string>Loading...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="21" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_7">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="leftMargin">
+      <number>4</number>
+     </property>
+     <property name="rightMargin">
+      <number>4</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label_bit14_2">
+       <property name="text">
+        <string>15</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit13_2">
+       <property name="text">
+        <string>14</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit12_2">
+       <property name="text">
+        <string>13</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit11_2">
+       <property name="text">
+        <string>12</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit10_2">
+       <property name="text">
+        <string>11</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit9_2">
+       <property name="text">
+        <string>10</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit8_2">
+       <property name="text">
+        <string>9</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit7_2">
+       <property name="text">
+        <string>8</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit6_2">
+       <property name="text">
+        <string>7</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit5_2">
+       <property name="text">
+        <string>6</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit4_2">
+       <property name="text">
+        <string>5</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit3_2">
+       <property name="text">
+        <string>4</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit2_2">
+       <property name="text">
+        <string>3</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit1_2">
+       <property name="text">
+        <string>2</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_bit0_2">
+       <property name="text">
+        <string>1</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="16" column="0" colspan="3">
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="33" column="0">
+    <widget class="QLabel" name="label_24">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Click &amp;quot;apply&amp;quot; to start the transmission override mode. Click &amp;quot;cancel&amp;quot; to return to the normal protection mode.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Apply Transmission Override:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="28" column="0">
+    <spacer name="horizontalSpacer_5">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="24" column="0" colspan="3">
+    <widget class="Line" name="line_4">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="3">
+    <widget class="Line" name="line_7">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="3">
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="19" column="0">
+    <widget class="QLabel" name="label_20">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;These are the allowed beamclasses that will be applied.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Beamclass Ranges [SC]:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="31" column="2">
+    <layout class="QHBoxLayout" name="horizontalLayout_11">
+     <item>
+      <widget class="PyDMByteIndicator" name="jf_active_byte">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>26</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>26</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}ApplyJF_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="jf_time_remaining">
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>50</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>2</number>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}TimeRemainJF_RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_27">
+       <property name="maximumSize">
+        <size>
+         <width>125</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <weight>50</weight>
+         <bold>false</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>hrs remaining</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="18" column="1">
+    <widget class="QComboBox" name="rateComboBox">
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="31" column="0">
+    <widget class="QLabel" name="label_22">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Readback and setpoint for the maximum credible energy in the context of a transmission override. If this is 5mJ, then we will use the maximum transmission protections. If this is set to lower than 5mJ and applied, then we will adjust all transmission protections proportionally.&lt;/p&gt;&lt;p&gt;Note that if we already have a transmission override applied, adjusting this parameter further will update the protection threshold, live.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Maximum Credible Energy:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="0">
+    <widget class="QLabel" name="label_14">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;These are the eV ranges that will be allowed after we apply.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Photon Energy Ranges:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="1" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout_6">
      <property name="spacing">
       <number>0</number>
@@ -1622,229 +2850,37 @@ and Zero BC</string>
      </item>
     </layout>
    </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_23">
+   <item row="30" column="0" colspan="3">
+    <widget class="Line" name="line_6">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0" colspan="3">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="20" column="0">
+    <widget class="QLabel" name="label_21">
      <property name="font">
       <font>
        <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
-     <property name="text">
-      <string>Duration/Timeout:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="3">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="5" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_9">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="PyDMLabel" name="jf_duration">
-       <property name="minimumSize">
-        <size>
-         <width>50</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>50</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="precision" stdset="0">
-        <number>2</number>
-       </property>
-       <property name="showUnits" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}DurationJF_RBV</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_25">
-       <property name="minimumSize">
-        <size>
-         <width>25</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>25</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>hrs</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_4">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>130</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="PyDMLineEdit" name="jf_duration_set">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>200</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="precision" stdset="0">
-        <number>2</number>
-       </property>
-       <property name="showUnits" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}DurationJF</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="0" column="1">
-    <widget class="PyDMLabel" name="PyDMLabel">
      <property name="toolTip">
-      <string/>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:Transmission_RBV</string>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="3">
-    <spacer name="horizontalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="15" column="0">
-    <widget class="QLabel" name="label_16">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the bit-by-bit selector for allowed beam classes.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
-      <string>Requested Rate [NC]:</string>
+      <string>Beamclass Range Select [SC]:</string>
      </property>
     </widget>
    </item>
-   <item row="26" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="17" column="0">
-    <widget class="QLabel" name="label_20">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Beamclass Ranges [SC]:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="21" column="1">
+   <item row="23" column="1">
     <widget class="QComboBox" name="beamclassComboBox">
      <property name="maximumSize">
       <size>
@@ -1854,113 +2890,7 @@ and Zero BC</string>
      </property>
     </widget>
    </item>
-   <item row="11" column="1" colspan="2">
-    <widget class="QFrame" name="frame_2">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>30</height>
-      </size>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::Panel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_4">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <property name="leftMargin">
-       <number>4</number>
-      </property>
-      <property name="topMargin">
-       <number>4</number>
-      </property>
-      <property name="rightMargin">
-       <number>4</number>
-      </property>
-      <property name="bottomMargin">
-       <number>4</number>
-      </property>
-      <item>
-       <widget class="EvByteIndicator" name="ev_rbv_bytes">
-        <property name="toolTip">
-         <string/>
-        </property>
-        <property name="alarmSensitiveContent" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="alarmSensitiveBorder" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="PyDMToolTip" stdset="0">
-         <string/>
-        </property>
-        <property name="channel" stdset="0">
-         <string>ca://${line_arbiter_prefix}BeamParamCntl:ReqBP:PhotonEnergyRanges_RBV</string>
-        </property>
-        <property name="orientation" stdset="0">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="showLabels" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="bigEndian" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="circles" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="numBits" stdset="0">
-         <number>32</number>
-        </property>
-        <property name="shift" stdset="0">
-         <number>0</number>
-        </property>
-        <property name="labels" stdset="0">
-         <stringlist>
-          <string>Bit 0</string>
-          <string>Bit 1</string>
-          <string>Bit 2</string>
-          <string>Bit 3</string>
-          <string>Bit 4</string>
-          <string>Bit 5</string>
-          <string>Bit 6</string>
-          <string>Bit 7</string>
-          <string>Bit 8</string>
-          <string>Bit 9</string>
-          <string>Bit 10</string>
-          <string>Bit 11</string>
-          <string>Bit 12</string>
-          <string>Bit 13</string>
-          <string>Bit 14</string>
-          <string>Bit 15</string>
-          <string>Bit 16</string>
-          <string>Bit 17</string>
-          <string>Bit 18</string>
-          <string>Bit 19</string>
-          <string>Bit 20</string>
-          <string>Bit 21</string>
-          <string>Bit 22</string>
-          <string>Bit 23</string>
-          <string>Bit 24</string>
-          <string>Bit 25</string>
-          <string>Bit 26</string>
-          <string>Bit 27</string>
-          <string>Bit 28</string>
-          <string>Bit 29</string>
-          <string>Bit 30</string>
-          <string>Bit 31</string>
-         </stringlist>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="18" column="1">
+   <item row="20" column="1">
     <widget class="QFrame" name="energy_range_frame_2">
      <property name="minimumSize">
       <size>
@@ -2239,705 +3169,7 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </layout>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_22">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Maximum Credible Energy:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_5">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="PyDMLabel" name="jf_cred_energy">
-       <property name="minimumSize">
-        <size>
-         <width>50</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>50</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="showUnits" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}IntensityJF_RBV</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_26">
-       <property name="minimumSize">
-        <size>
-         <width>25</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>25</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>mJ</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>130</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="PyDMLineEdit" name="jf_cred_energy_set">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>200</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="precision" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="showUnits" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}IntensityJF</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="12" column="1" colspan="2">
-    <widget class="QFrame" name="energy_range_frame">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>26</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="layoutDirection">
-      <enum>Qt::LeftToRight</enum>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::Panel</enum>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <property name="leftMargin">
-       <number>6</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QCheckBox" name="bit31">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit30">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit29">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit28">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit27">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit26">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit25">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit24">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit23">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit22">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit21">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit20">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit19">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit18">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit17">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit16">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit15">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit14">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit13">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit12">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit11">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit10">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit9">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit8">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit7">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit6">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit5">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit4">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit3">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit2">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit1">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="bit0">
-        <property name="styleSheet">
-         <string notr="true">QCheckBox::indicator:unchecked {background-color: rgb(180, 180, 180); }
-QCheckBox::indicator::checked {background-color: green;}
-QCheckBox::indicator:checked:disabled {background-color: rgb(120, 166, 142);}
-QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="1">
+   <item row="3" column="1">
     <widget class="PyDMLineEdit" name="transEdit">
      <property name="enabled">
       <bool>false</bool>
@@ -2974,295 +3206,192 @@ QCheckBox::indicator:unchecked:disabled {background-color: rgb(224, 224, 224);}<
      </property>
     </widget>
    </item>
-   <item row="3" column="0" colspan="3">
-    <widget class="Line" name="line_3">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="33" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_10">
+     <item>
+      <widget class="PyDMPushButton" name="jf_cancel">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>200</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: rgb(255, 85, 85);</string>
+       </property>
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}CancelJF</string>
+       </property>
+       <property name="passwordProtected" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="password" stdset="0">
+        <string/>
+       </property>
+       <property name="protectedPassword" stdset="0">
+        <string/>
+       </property>
+       <property name="showConfirmDialog" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="confirmMessage" stdset="0">
+        <string>Are you sure you want to proceed?</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+       <property name="releaseValue" stdset="0">
+        <string>None</string>
+       </property>
+       <property name="relativeChange" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="writeWhenRelease" stdset="0">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMPushButton" name="jf_apply">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>200</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: rgb(148, 255, 85);</string>
+       </property>
+       <property name="text">
+        <string>Apply</string>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}ApplyJF</string>
+       </property>
+       <property name="passwordProtected" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="password" stdset="0">
+        <string/>
+       </property>
+       <property name="protectedPassword" stdset="0">
+        <string/>
+       </property>
+       <property name="showConfirmDialog" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="confirmMessage" stdset="0">
+        <string>Are you sure you want to proceed?</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+       <property name="releaseValue" stdset="0">
+        <string>None</string>
+       </property>
+       <property name="relativeChange" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="writeWhenRelease" stdset="0">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="17" column="0">
+    <widget class="QLabel" name="label_16">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the maximum NC rate that we will enforce one we apply the parameters.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Requested Rate [NC]:</string>
      </property>
     </widget>
    </item>
-   <item row="19" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_7">
-     <property name="spacing">
-      <number>0</number>
+   <item row="32" column="0">
+    <widget class="QLabel" name="label_23">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
      </property>
-     <property name="leftMargin">
-      <number>4</number>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the timeout after which we will remove our transmission override. It is intended to be overridden for the length of a single shift.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
-     <property name="rightMargin">
-      <number>4</number>
+     <property name="text">
+      <string>Duration/Timeout:</string>
      </property>
-     <item>
-      <widget class="QLabel" name="label_bit14_2">
-       <property name="text">
-        <string>15</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit13_2">
-       <property name="text">
-        <string>14</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit12_2">
-       <property name="text">
-        <string>13</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit11_2">
-       <property name="text">
-        <string>12</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit10_2">
-       <property name="text">
-        <string>11</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit9_2">
-       <property name="text">
-        <string>10</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit8_2">
-       <property name="text">
-        <string>9</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit7_2">
-       <property name="text">
-        <string>8</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit6_2">
-       <property name="text">
-        <string>7</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit5_2">
-       <property name="text">
-        <string>6</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit4_2">
-       <property name="text">
-        <string>5</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit3_2">
-       <property name="text">
-        <string>4</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit2_2">
-       <property name="text">
-        <string>3</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit1_2">
-       <property name="text">
-        <string>2</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_bit0_2">
-       <property name="text">
-        <string>1</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    </widget>
    </item>
-   <item row="4" column="2">
-    <layout class="QHBoxLayout" name="horizontalLayout_11">
-     <item>
-      <widget class="PyDMByteIndicator" name="jf_active_byte">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>26</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>26</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}ApplyJF_RBV</string>
-       </property>
-       <property name="showLabels" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="bigEndian" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="circles" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="numBits" stdset="0">
-        <number>1</number>
-       </property>
-       <property name="shift" stdset="0">
-        <number>0</number>
-       </property>
-       <property name="labels" stdset="0">
-        <stringlist>
-         <string>Bit 0</string>
-        </stringlist>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="PyDMLabel" name="jf_time_remaining">
-       <property name="minimumSize">
-        <size>
-         <width>50</width>
-         <height>26</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>50</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="precision" stdset="0">
-        <number>2</number>
-       </property>
-       <property name="showUnits" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="precisionFromPV" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveContent" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>true</bool>
-       </property>
-       <property name="PyDMToolTip" stdset="0">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://${line_arbiter_prefix}TimeRemainJF_RBV</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_27">
-       <property name="maximumSize">
-        <size>
-         <width>125</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <weight>50</weight>
-         <bold>false</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>hrs remaining</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="29" column="0">
+    <widget class="QLabel" name="label_29">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use this section to globally relax the transmission requirements. The transmission requirements are designed to protect us from a 5mJ beam. If your beam is substantially weaker than 5mJ, you can put in the maximum credible energy here to temporarily adjust all of the transmission protections to compensate.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Transmission Override</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/pmps.py
+++ b/pmps.py
@@ -177,12 +177,13 @@ class PMPS(Display):
         self.setup_arbiter_outputs()
         self.setup_ev_calculation()
         self.setup_line_parameters_control()
+        self.setup_trans_override()
         self.setup_plc_ioc_status()
         self.setup_beam_class_table()
 
         dash_url = self.config.get('dashboard_url')
         if self.user_args.no_web or dash_url is None:
-            self.ui.tab_arbiter_outputs.removeTab(7)
+            self.ui.tab_arbiter_outputs.removeTab(8)
         else:
             self.setup_grafana_log_display()
 
@@ -220,6 +221,12 @@ class PMPS(Display):
         tab = self.ui.tb_line_beam_param_ctrl
         beam_widget = LineBeamParametersControl(macros=self.config)
         tab.layout().addWidget(beam_widget)
+
+    def setup_trans_override(self):
+        from trans_override import TransOverride
+        tab = self.ui.tb_trans_override
+        jf_widget = TransOverride(macros=self.config)
+        tab.layout().addWidget(jf_widget)
 
     def setup_plc_ioc_status(self):
         from plc_ioc_status import PLCIOCStatus

--- a/pmps.py
+++ b/pmps.py
@@ -53,6 +53,8 @@ class PMPS(Display):
             'line_arbiter_prefix',
             'undulator_kicker_rate_pv',
             'accelerator_mode_pv',
+            'trans_req_pv',
+            'trans_rbv_pv',
         ]
 
         for m in macros_from_config:

--- a/pmps.py
+++ b/pmps.py
@@ -187,6 +187,10 @@ class PMPS(Display):
         else:
             self.setup_grafana_log_display()
 
+        line_arbiter_prefix = self.config.get("line_arbiter_prefix", "")
+        if "LFE" in line_arbiter_prefix:
+            self.ui.tab_arbiter_outputs.removeTab(6)
+
         # We are done... re-enable painting
         self.setUpdatesEnabled(True)
 

--- a/pmps.ui
+++ b/pmps.ui
@@ -132,7 +132,7 @@
      <item>
       <widget class="QFrame" name="frame_2">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+        <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -146,7 +146,7 @@
        <property name="maximumSize">
         <size>
          <width>16777215</width>
-         <height>500</height>
+         <height>150</height>
         </size>
        </property>
        <property name="frameShape">
@@ -571,7 +571,7 @@
         <bool>true</bool>
        </property>
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+        <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -585,7 +585,7 @@
        <property name="maximumSize">
         <size>
          <width>16777215</width>
-         <height>500</height>
+         <height>150</height>
         </size>
        </property>
        <property name="autoFillBackground">

--- a/pmps.ui
+++ b/pmps.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1200</width>
-    <height>742</height>
+    <height>375</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -1843,6 +1843,12 @@
        <string>Line Beam Parameters Control</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_7"/>
+     </widget>
+     <widget class="QWidget" name="tb_trans_override">
+      <attribute name="title">
+       <string>Transmission Override</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_12"/>
      </widget>
      <widget class="QWidget" name="tb_beamclass_table">
       <attribute name="title">

--- a/pmps.ui
+++ b/pmps.ui
@@ -219,13 +219,13 @@
              <string/>
             </property>
             <property name="precision" stdset="0">
-             <number>0</number>
+             <number>2</number>
             </property>
             <property name="showUnits" stdset="0">
              <bool>true</bool>
             </property>
             <property name="precisionFromPV" stdset="0">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="alarmSensitiveContent" stdset="0">
              <bool>false</bool>
@@ -318,13 +318,13 @@
              <string/>
             </property>
             <property name="precision" stdset="0">
-             <number>0</number>
+             <number>2</number>
             </property>
             <property name="showUnits" stdset="0">
              <bool>true</bool>
             </property>
             <property name="precisionFromPV" stdset="0">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="alarmSensitiveContent" stdset="0">
              <bool>false</bool>

--- a/pmps.ui
+++ b/pmps.ui
@@ -227,8 +227,17 @@
             <property name="precisionFromPV" stdset="0">
              <bool>true</bool>
             </property>
+            <property name="alarmSensitiveContent" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="alarmSensitiveBorder" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="PyDMToolTip" stdset="0">
+             <string/>
+            </property>
             <property name="channel" stdset="0">
-             <string>ca://${line_arbiter_prefix}RequestedBP:Transmission_RBV</string>
+             <string>ca://${trans_req_pv}</string>
             </property>
             <property name="displayFormat" stdset="0">
              <enum>PyDMLabel::Exponential</enum>
@@ -317,8 +326,17 @@
             <property name="precisionFromPV" stdset="0">
              <bool>true</bool>
             </property>
+            <property name="alarmSensitiveContent" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="alarmSensitiveBorder" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="PyDMToolTip" stdset="0">
+             <string/>
+            </property>
             <property name="channel" stdset="0">
-             <string>ca://${line_arbiter_prefix}CurrentBP:Transmission_RBV</string>
+             <string>ca://${trans_rbv_pv}</string>
             </property>
             <property name="displayFormat" stdset="0">
              <enum>PyDMLabel::Exponential</enum>

--- a/preemptive_requests.py
+++ b/preemptive_requests.py
@@ -77,6 +77,11 @@ class PreemptiveRequests(Display):
         for col in range(1, ncols):
             reqs_table.hideColumn(col)
 
+        # LFE doesn't have the jf override mechanisms, hide it for clarity
+        if "LFE" in line_arbiter_prefix:
+            # This is the header text that contains "5mJ"
+            self.ui.table_header.embedded_widget.trans_5mj_header.hide()
+
         count = 0
         self.row_logics = []
         self.backcompat = BackCompat(parent=self)
@@ -177,6 +182,12 @@ class PreemptiveRequests(Display):
                 self._channels.append(jf_trans_channel)
                 self._channels.append(jf_value_channel)
                 self._channels.append(jf_on_channel)
+
+                # LFE doesn't have the jf override mechanisms, hide it for clarity
+                if "LFE" in line_arbiter_prefix:
+                    # Hide the raw value that goes under the 5mJ header
+                    # Keep the calculated value under the "Transmission" header
+                    widget.embedded_widget.transmission_label.hide()
 
                 # insert the widget you see into the table
                 row_position = reqs_table.rowCount()

--- a/preemptive_requests.py
+++ b/preemptive_requests.py
@@ -396,19 +396,41 @@ class PreemptiveRequests(Display):
         valid_rate = get_valid_rate(value)
         label.setText(f'{valid_rate} Hz')
 
-    def update_jf_from_raw_trans(self, value, label):
+    def update_jf_from_raw_trans(self, value: float, label: QtWidgets.QLabel) -> None:
+        """
+        Slot to recieve and use a new transmission readback.
+
+        This is combined with the incoming jf data to update
+        the effective transmission readback.
+        """
         self.jf_trans_cache[label.channel] = value
         self.update_jf_trans_for_label(label)
 
-    def update_jf_from_jf(self, value, label):
+    def update_jf_from_jf(self, value: float , label: QtWidgets.QLabel) -> None:
+        """
+        Slot to recieve and use a new judgement factor readback.
+
+        This is used to adjust the raw transmission to
+        update the effective transmission readback.
+        """
         self.jf_value_cache = value or 5
         self.update_jf_trans_for_label(label)
 
-    def update_jf_from_on(self, value, label):
+    def update_jf_from_on(self, value: bool, label: QtWidgets.QLabel) -> None:
+        """
+        Slot to recieve and use a new jugement factor on/off readback.
+
+        Ths value is True if the judgement factor is active, and
+        False otherwise. We can use this to know whether or not to
+        consider the judgement factor value.
+        """
         self.jf_on_cache = value
         self.update_jf_trans_for_label(label)
 
-    def update_jf_trans_for_label(self, label):
+    def update_jf_trans_for_label(self, label: QtWidgets.QLabel) -> None:
+        """
+        Update one label's transmission readback based on the judgement factor.
+        """
         try:
             raw_trans = self.jf_trans_cache[label.channel]
         except KeyError:

--- a/single_tab.py
+++ b/single_tab.py
@@ -1,6 +1,5 @@
 import argparse
 import os.path
-import sys
 
 import yaml
 from pcdsutils.profile import profiler_context
@@ -15,6 +14,7 @@ from grafana_log_display import GrafanaLogDisplay
 from line_beam_parameters import LineBeamParametersControl
 from plc_ioc_status import PLCIOCStatus
 from preemptive_requests import PreemptiveRequests
+from trans_override import TransOverride
 
 options = {
     'fast_faults': FastFaults,
@@ -22,6 +22,7 @@ options = {
     'arbiter_outputs': ArbiterOutputs,
     'ev_calculation': EVCalculation,
     'line_beam_parameters': LineBeamParametersControl,
+    'trans_override': TransOverride,
     'plc_ioc_status': PLCIOCStatus,
     'grafana_log_dispaly': GrafanaLogDisplay,
 }

--- a/templates/preemptive_requests_entry.ui
+++ b/templates/preemptive_requests_entry.ui
@@ -6,19 +6,19 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1453</width>
+    <width>1555</width>
     <height>40</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>1453</width>
+    <width>1555</width>
     <height>40</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>1453</width>
+    <width>1555</width>
     <height>40</height>
    </size>
   </property>
@@ -236,6 +236,28 @@
      </property>
      <property name="numBits" stdset="0">
       <number>15</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="jf_trans_label">
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>100</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
      </property>
     </widget>
    </item>

--- a/templates/preemptive_requests_header.ui
+++ b/templates/preemptive_requests_header.ui
@@ -256,7 +256,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QLabel" name="label_13">
+          <widget class="QLabel" name="trans_header">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
              <horstretch>0</horstretch>
@@ -290,7 +290,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QLabel" name="label_12">
+          <widget class="QLabel" name="trans_5mj_header">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
              <horstretch>0</horstretch>

--- a/templates/preemptive_requests_header.ui
+++ b/templates/preemptive_requests_header.ui
@@ -6,19 +6,19 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1453</width>
+    <width>1555</width>
     <height>47</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>1453</width>
+    <width>1555</width>
     <height>47</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>1459</width>
+    <width>1559</width>
     <height>47</height>
    </size>
   </property>
@@ -256,7 +256,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QLabel" name="label_12">
+          <widget class="QLabel" name="label_13">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
              <horstretch>0</horstretch>
@@ -283,6 +283,40 @@
            </property>
            <property name="text">
             <string>Transmission</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_12">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>100</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>100</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Trans at 5mJ</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignCenter</set>
@@ -432,7 +466,7 @@
      </property>
      <property name="maximumSize">
       <size>
-       <width>1453</width>
+       <width>1555</width>
        <height>16777215</height>
       </size>
      </property>

--- a/trans_override.py
+++ b/trans_override.py
@@ -1,0 +1,26 @@
+from pydm import Display
+
+
+class TransOverride(Display):
+    """
+    Class to handle display for the Transmission Override tab.
+    """
+
+    def __init__(self, parent=None, args=None, macros=None):
+        super().__init__(parent=parent, args=args, macros=macros)
+        self.config = macros
+        self._channels = []
+        self.setup_ui()
+
+    def channels(self):
+        "Make sure PyDM can find the channels we set up for cleanup."
+        return self._channels
+
+    def ui_filename(self):
+        return 'trans_override.ui'
+
+    def setup_ui(self):
+        # There's no special setup for this tab yet
+        # All calculations related to the values set here
+        # are needed only in other tabs
+        ...

--- a/trans_override.ui
+++ b/trans_override.ui
@@ -1,0 +1,720 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>858</width>
+    <height>391</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="3" column="2">
+    <widget class="PyDMLineEdit" name="jf_duration_set">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>200</width>
+       <height>26</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="precision" stdset="0">
+      <number>2</number>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="precisionFromPV" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="PyDMToolTip" stdset="0">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${line_arbiter_prefix}DurationJF</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="4">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_24">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Click &amp;quot;apply&amp;quot; to start the transmission override mode. Click &amp;quot;cancel&amp;quot; to return to the normal protection mode.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Apply Transmission Override:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="PyDMPushButton" name="jf_cancel">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>200</width>
+       <height>26</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QPushButton { background-color: rgb(255, 85, 85) }</string>
+     </property>
+     <property name="text">
+      <string>Cancel</string>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="PyDMToolTip" stdset="0">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${line_arbiter_prefix}CancelJF</string>
+     </property>
+     <property name="passwordProtected" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="password" stdset="0">
+      <string/>
+     </property>
+     <property name="protectedPassword" stdset="0">
+      <string/>
+     </property>
+     <property name="showConfirmDialog" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="confirmMessage" stdset="0">
+      <string>Are you sure you want to proceed?</string>
+     </property>
+     <property name="pressValue" stdset="0">
+      <string>1</string>
+     </property>
+     <property name="releaseValue" stdset="0">
+      <string>None</string>
+     </property>
+     <property name="relativeChange" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="writeWhenRelease" stdset="0">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="PyDMLineEdit" name="jf_cred_energy_set">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>200</width>
+       <height>26</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="precision" stdset="0">
+      <number>0</number>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="precisionFromPV" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="PyDMToolTip" stdset="0">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${line_arbiter_prefix}IntensityJF</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_29">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use this section to globally relax the transmission requirements. The transmission requirements are designed to protect us from a 5mJ beam. If your beam is substantially weaker than 5mJ, you can put in the maximum credible energy here to temporarily adjust all of the transmission protections to compensate.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Transmission Override</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_22">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Readback and setpoint for the maximum credible energy in the context of a transmission override. If this is 5mJ, then we will use the maximum transmission protections. If this is set to lower than 5mJ and applied, then we will adjust all transmission protections proportionally.&lt;/p&gt;&lt;p&gt;Note that if we already have a transmission override applied, adjusting this parameter further will update the protection threshold, live.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Maximum Credible Energy:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="4">
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="4">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="PyDMLabel" name="jf_cred_energy">
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>50</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}IntensityJF_RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_26">
+       <property name="minimumSize">
+        <size>
+         <width>25</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>25</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>mJ</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>130</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="4" column="2">
+    <widget class="PyDMPushButton" name="jf_apply">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>200</width>
+       <height>26</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>26</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QPushButton { background-color: rgb(148, 255, 85) }</string>
+     </property>
+     <property name="text">
+      <string>Apply</string>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="PyDMToolTip" stdset="0">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${line_arbiter_prefix}ApplyJF</string>
+     </property>
+     <property name="passwordProtected" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="password" stdset="0">
+      <string/>
+     </property>
+     <property name="protectedPassword" stdset="0">
+      <string/>
+     </property>
+     <property name="showConfirmDialog" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="confirmMessage" stdset="0">
+      <string>Warning: this override will unilaterally relax the transmission requirements for all devices, increasing the effective beam intensity. It should only be used when the beam is abnormally weak compared to the assumptions made when establishing the PMPS requirements (5mJ beam). You will also need to reapply the &quot;Line Beam Parameters&quot; configuration for transmission to keep everything consistent. Are you sure you wish to proceed?</string>
+     </property>
+     <property name="pressValue" stdset="0">
+      <string>1</string>
+     </property>
+     <property name="releaseValue" stdset="0">
+      <string>None</string>
+     </property>
+     <property name="relativeChange" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="writeWhenRelease" stdset="0">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_31">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>Usage Notes</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_9">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="PyDMLabel" name="jf_duration">
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>50</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>2</number>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}DurationJF_RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_25">
+       <property name="minimumSize">
+        <size>
+         <width>25</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>25</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>hrs</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>130</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="5" column="0">
+    <spacer name="horizontalSpacer_5">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="3">
+    <layout class="QHBoxLayout" name="horizontalLayout_11">
+     <item>
+      <widget class="PyDMByteIndicator" name="jf_active_byte">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>26</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>26</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}ApplyJF_RBV</string>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="bigEndian" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="numBits" stdset="0">
+        <number>1</number>
+       </property>
+       <property name="shift" stdset="0">
+        <number>0</number>
+       </property>
+       <property name="labels" stdset="0">
+        <stringlist>
+         <string>Bit 0</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PyDMLabel" name="jf_time_remaining">
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>26</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>50</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>2</number>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveContent" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="PyDMToolTip" stdset="0">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${line_arbiter_prefix}TimeRemainJF_RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_27">
+       <property name="maximumSize">
+        <size>
+         <width>125</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <weight>50</weight>
+         <bold>false</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>hrs remaining</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_23">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the timeout after which we will remove our transmission override. It is intended to be overridden for the length of a single shift.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Duration/Timeout:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="4">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>- Use of this override necessarily makes the beam less safe by relaxing the gas detector requirements.
+
+- The PMPS transmission parameters were set with an assumed maximum credible energy of 5 mJ.
+  When this assumption is wildly wrong, you may use this override to globally adjust the requirements for a shift duration.
+
+- Transmission adjustments are proportional, e.g. a maximum credible energy of 0.5 mJ would result in all
+  transmissions being multipled by 10 (capped at 1.0 = 100% transmission).
+
+- You should reset and reapply the line beam parameter transmission select after performing this override if you need it for your shift.
+  This override will adjust any active line beam parameter transmission requests in-place in an unintuitive way.
+  Once overriden, new line beam parameter transmission requests will be scaled appropriately.</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMByteIndicator</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.byte</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>pydm.widgets.line_edit</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMPushButton</class>
+   <extends>QPushButton</extends>
+   <header>pydm.widgets.pushbutton</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/trans_override.ui
+++ b/trans_override.ui
@@ -350,73 +350,6 @@
      </item>
     </layout>
    </item>
-   <item row="4" column="2">
-    <widget class="PyDMPushButton" name="jf_apply">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>200</width>
-       <height>26</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>200</width>
-       <height>26</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">QPushButton { background-color: rgb(148, 255, 85) }</string>
-     </property>
-     <property name="text">
-      <string>Apply</string>
-     </property>
-     <property name="alarmSensitiveContent" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="alarmSensitiveBorder" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="PyDMToolTip" stdset="0">
-      <string/>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${line_arbiter_prefix}ApplyJF</string>
-     </property>
-     <property name="passwordProtected" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="password" stdset="0">
-      <string/>
-     </property>
-     <property name="protectedPassword" stdset="0">
-      <string/>
-     </property>
-     <property name="showConfirmDialog" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="confirmMessage" stdset="0">
-      <string>Warning: this override will unilaterally relax the transmission requirements for all devices, increasing the effective beam intensity. It should only be used when the beam is abnormally weak compared to the assumptions made when establishing the PMPS requirements (5mJ beam). You will also need to reapply the &quot;Line Beam Parameters&quot; configuration for transmission to keep everything consistent. Are you sure you wish to proceed?</string>
-     </property>
-     <property name="pressValue" stdset="0">
-      <string>1</string>
-     </property>
-     <property name="releaseValue" stdset="0">
-      <string>None</string>
-     </property>
-     <property name="relativeChange" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="writeWhenRelease" stdset="0">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
    <item row="6" column="0">
     <widget class="QLabel" name="label_31">
      <property name="font">
@@ -688,6 +621,73 @@
 - You should reset and reapply the line beam parameter transmission select after performing this override if you need it for your shift.
   This override will adjust any active line beam parameter transmission requests in-place in an unintuitive way.
   Once overriden, new line beam parameter transmission requests will be scaled appropriately.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="2">
+    <widget class="PyDMPushButton" name="jf_apply_2">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>200</width>
+       <height>26</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>26</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QPushButton { background-color: rgb(148, 255, 85) }</string>
+     </property>
+     <property name="text">
+      <string>Apply</string>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="PyDMToolTip" stdset="0">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${line_arbiter_prefix}ApplyJF</string>
+     </property>
+     <property name="passwordProtected" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="password" stdset="0">
+      <string/>
+     </property>
+     <property name="protectedPassword" stdset="0">
+      <string/>
+     </property>
+     <property name="showConfirmDialog" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="confirmMessage" stdset="0">
+      <string>Warning: this override will adjust transmission requirements globally, making the beam much stronger. Are you sure you wish to proceed?</string>
+     </property>
+     <property name="pressValue" stdset="0">
+      <string>1</string>
+     </property>
+     <property name="releaseValue" stdset="0">
+      <string>None</string>
+     </property>
+     <property name="relativeChange" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="writeWhenRelease" stdset="0">
+      <bool>false</bool>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
This PR is a companion to https://github.com/pcdshub/lcls-plc-kfe-arbiter/pull/20
In that PR, Maggie adds code and PVs for a user "Judgement Factor" that essentially acts as a PMPS transmission override.

This PR uses those PVs to:

- Add a section to the line_beam_parameters tab for setting transmission overrides
- Act as a middleman for transmission read/write so that this still works as expected
- Add a column to the pre-emptive requests tab that acts as the "adjusted" effective transmission values.

I feel pretty good about most of it.
The transmission read/write feels somewhat janky to me. I cannot (should not) make the UI write to PVs unprompted, so I think this is the best I can do in the python layer without creating horrors, but it still feels a bit off.

Updated pre-emptive requests tab (there are now 2 columns for transmission):
![image](https://github.com/pcdshub/pmps-ui/assets/10647860/0dab5f52-7af4-4077-a913-ffd41fad3032)


Updated line beam parameters tab (added section headers, new section at the bottom, added tooltips):
![image](https://github.com/pcdshub/pmps-ui/assets/10647860/b3a7228f-781b-43eb-8c70-4fdfda74d123)
