### PR TITLE
fix(PLC:KFE:VAC:KO:FFO:05): extended the ffo_end for the KFE VAC fast faults to catch a 5th fault because we had a collision with the fault numbers on the PLC end

### DIFF
--- a/KFE_config.yml
+++ b/KFE_config.yml
@@ -21,7 +21,7 @@ fastfaults:
 
   - prefix: "PLC:KFE:VAC:K0:"
     ffo_start: 1
-    ffo_end: 4
+    ffo_end: 5
     ff_start: 1
     ff_end: 20
 


### PR DESCRIPTION
## Description & Motivation
[PR #36 for lcls-plc-kfe-vac](https://github.com/pcdshub/lcls-plc-kfe-vac/pull/36) addresses a collision in the fast fault integer enumeration for the KFE vacuum system. This PR extends the `ffo_end` field for the `PLC:KFE:VAC:K0:` fast fault to accept that incremented integer.

## Linked PRs
- https://github.com/pcdshub/lcls-plc-kfe-vac/pull/36

## Testing
- [ ] Close VFS-1 and see if we see it in PMPS Diag