### PR TITLE
ENH: FF/FFO Veto Visualizations

### DIFF
--- a/KFE_config.yml
+++ b/KFE_config.yml
@@ -7,73 +7,85 @@ trans_rbv_pv: "AT1K0:GAS:TRANS_RBV"
 dashboard_url: "http://ctl-logsrv01:3000/ctl/grafana/d/PRr2cuGGz/k-pmps-events?viewPanel=2&orgId=1&refresh=10s&kiosk"
 
 fastfaults:
-  - prefix: "PMPS:KFE:"
+  - name: "KFE Arbiter"
+    prefix: "PMPS:KFE:"
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
     ff_end: 50
 
-  - prefix: "PLC:KFE:GATT:"
+  - name: "KFE GATT"
+    prefix: "PLC:KFE:GATT:"
     ffo_start: 1
     ffo_end: 1
     ff_start: 1
     ff_end: 75
 
-  - prefix: "PLC:KFE:VAC:K0:"
+  - name: "KFE Vacuum"
+    prefix: "PLC:KFE:VAC:K0:"
     ffo_start: 1
     ffo_end: 5
     ff_start: 1
     ff_end: 20
 
-  - prefix: "PLC:TMO:VAC:"
+  - name: "TMO Vacuum"
+    prefix: "PLC:TMO:VAC:"
     ffo_start: 1
     ffo_end: 6
     ff_start: 1
     ff_end: 50
 
-  - prefix: "PLC:TMO:OPTICS:"
+  - name: "TMO Optics"
+    prefix: "PLC:TMO:OPTICS:"
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
     ff_end: 50
 
-  - prefix: "PLC:TMO:MOTION:"
+  - name: "TMO CC Motion"
+    prefix: "PLC:TMO:MOTION:"
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
     ff_end: 200
 
-  - prefix: "PLC:KFE:MOTION:"
+  - name: "KFE CC Motion"
+    prefix: "PLC:KFE:MOTION:"
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
     ff_end: 50
 
-  - prefix: "PLC:RIX:OPTICS:"
+  - name: "RIX Optics"
+    prefix: "PLC:RIX:OPTICS:"
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
     ff_end: 50
 
-  - prefix: "PLC:KFE:RIX:VAC:K2:"
+  - name: "RIX Vacuum"
+    prefix: "PLC:KFE:RIX:VAC:K2:"
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
     ff_end: 50
 
-  - prefix: "PLC:RIX:MOTION:"
+  - name: "RIX CC Motion"
+    prefix: "PLC:RIX:MOTION:"
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
     ff_end: 200
 
-  - prefix: "PLC:CRIXS:VAC:"
+  - name: "CRIX Vacuum"
+    prefix: "PLC:CRIXS:VAC:"
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
     ff_end: 50
 
-  - prefix: "PLC:CRIX:MOT:"
+  - name: "CRIX Motion"
+    prefix: "PLC:CRIX:MOT:"
     ffo_start: 1
     ffo_end: 2
     ff_start: 1

--- a/KFE_config.yml
+++ b/KFE_config.yml
@@ -9,6 +9,8 @@ dashboard_url: "http://ctl-logsrv01:3000/ctl/grafana/d/PRr2cuGGz/k-pmps-events?v
 fastfaults:
   - name: "KFE Arbiter"
     prefix: "PMPS:KFE:"
+    ffo_desc: ["PMPS System", "Spare"]
+    ffo_veto: ["None", "None"]
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
@@ -16,13 +18,27 @@ fastfaults:
 
   - name: "KFE GATT"
     prefix: "PLC:KFE:GATT:"
+    ffo_desc: ["All KFE GATT", "Spare"]
+    ffo_veto: ["None", "None"]
     ffo_start: 1
-    ffo_end: 1
+    ffo_end: 2
     ff_start: 1
     ff_end: 75
 
   - name: "KFE Vacuum"
     prefix: "PLC:KFE:VAC:K0:"
+    ffo_desc:
+      - "K0 Upstream"
+      - "K2/RIX"
+      - "K3/TXI"
+      - "K4/TMO"
+      - "K0 Fast Shutters"
+    ffo_veto:
+      - "None"
+      - "MR1K1 OUT"
+      - "MR1K1 IN or MR1K3 OUT"
+      - "MR1K1 IN or MR1K3 IN"
+      - "None"
     ffo_start: 1
     ffo_end: 5
     ff_start: 1
@@ -30,6 +46,20 @@ fastfaults:
 
   - name: "TMO Vacuum"
     prefix: "PLC:TMO:VAC:"
+    ffo_desc:
+      - "Upstream of ST3K4"
+      - "From ST3K4 to ST4K4"
+      - "TV1K4 Fast Shutter"
+      - "US Mirror Fast Shutters"
+      - "Downstream of ST4K4"
+      - "DS Mirror Fast Shutters"
+    ffo_veto:
+      - "MR1K1 IN"
+      - "MR1K1 or ST3K4 IN"
+      - "MR1K1 IN"
+      - "MR1K1 or ST3K4 IN"
+      - "MR1K1, ST3K4, or ST4K4 IN"
+      - "MR1K1, ST3K4, or ST4K4 IN"
     ffo_start: 1
     ffo_end: 6
     ff_start: 1
@@ -37,6 +67,8 @@ fastfaults:
 
   - name: "TMO Optics"
     prefix: "PLC:TMO:OPTICS:"
+    ffo_desc: ["Upstream of ST3K4", "Downstream of ST3K4"]
+    ffo_veto: ["MR1K1 IN", "MR1K1 or ST3K4 IN"]
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
@@ -44,6 +76,8 @@ fastfaults:
 
   - name: "TMO CC Motion"
     prefix: "PLC:TMO:MOTION:"
+    ffo_desc: ["Upstream of ST4K4", "Downstream of ST4K4"]
+    ffo_veto: ["MR1K1 or ST3K4 IN", "MR1K1 or ST3K4 or ST4K4 IN"]
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
@@ -51,6 +85,8 @@ fastfaults:
 
   - name: "KFE CC Motion"
     prefix: "PLC:KFE:MOTION:"
+    ffo_desc: ["Upstream of MR1K1", "Downstream of MR1K1"]
+    ffo_veto: ["None", "MR1K1 IN"]
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
@@ -58,6 +94,8 @@ fastfaults:
 
   - name: "RIX Optics"
     prefix: "PLC:RIX:OPTICS:"
+    ffo_desc: ["Upstream of ST1K2", "Downstream of ST1K2"]
+    ffo_veto: ["MR1K1 OUT", "MR1K1 OUT or ST1K2 IN"]
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
@@ -65,6 +103,8 @@ fastfaults:
 
   - name: "RIX Vacuum"
     prefix: "PLC:KFE:RIX:VAC:K2:"
+    ffo_desc: ["Upstream of ST1K2", "Downstream of ST1K2"]
+    ffo_veto: ["MR1K1 OUT", "MR1K1 OUT or ST1K2 IN"]
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
@@ -72,6 +112,8 @@ fastfaults:
 
   - name: "RIX CC Motion"
     prefix: "PLC:RIX:MOTION:"
+    ffo_desc: ["Upstream of ST1K2", "Downstream of ST1K2"]
+    ffo_veto: ["MR1K1 OUT", "MR1K1 OUT or ST1K2 IN"]
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
@@ -79,6 +121,8 @@ fastfaults:
 
   - name: "CRIX Vacuum"
     prefix: "PLC:CRIXS:VAC:"
+    ffo_desc: ["All CRIX Vac", "Spare"]
+    ffo_veto: ["MR1K1 OUT or ST1K2 IN", "MR1K1 OUT or ST1K2 IN"]
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
@@ -86,6 +130,8 @@ fastfaults:
 
   - name: "CRIX Motion"
     prefix: "PLC:CRIX:MOT:"
+    ffo_desc: ["Spare", "Spare"]
+    ffo_veto: ["MR1K1 OUT or ST1K2 IN", "MR1K1 OUT or ST1K2 IN"]
     ffo_start: 1
     ffo_end: 2
     ff_start: 1

--- a/LFE_config.yml
+++ b/LFE_config.yml
@@ -8,61 +8,71 @@ dashboard_url: "http://ctl-logsrv01:3000/ctl/grafana/d/PQBzCnmMz/l-pmps-events?r
 
 
 fastfaults:
-  - prefix: "PMPS:LFE:"
+  - name: "LFE Arbiter"
+    prefix: "PMPS:LFE:"
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
     ff_end: 50
 
-  - prefix: "PLC:LFE:VAC:"
+  - name: "LFE Vacuum"
+    prefix: "PLC:LFE:VAC:"
     ffo_start: 1
     ffo_end: 3
     ff_start: 1
     ff_end: 50
 
-  - prefix: "PLC:LFE:GEM:"
+  - name: "LFE GEM"
+    prefix: "PLC:LFE:GEM:"
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
     ff_end: 50
 
-  - prefix: "PLC:LFE:MOTION:"
+  - name: "LFE CC Motion"
+    prefix: "PLC:LFE:MOTION:"
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
     ff_end: 50
 
-  - prefix: "PLC:LFE:OPTICS:"
+  - name: "LFE Optics"
+    prefix: "PLC:LFE:OPTICS:"
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
     ff_end: 50
 
-  - prefix: "PLC:XRT:OPTICS:"
+  - name: "XRT Optics"
+    prefix: "PLC:XRT:OPTICS:"
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
     ff_end: 50
 
-  - prefix: "PLC:TXI:MOTION:"
+  - name: "TXI CC Motion"
+    prefix: "PLC:TXI:MOTION:"
     ffo_start: 1
     ffo_end: 1
     ff_start: 1
     ff_end: 50
 
-  - prefix: "PLC:TXI:HXR:VAC:"
+  - name: "TXI LFE VAC"
+    prefix: "PLC:TXI:HXR:VAC:"
     ffo_start: 1
     ffo_end: 1
     ff_start: 1
     ff_end: 50
 
-  - prefix: "PLC:TXI:HXR:VAC:L1"
+  - name: "TXI L1 VAC"
+    prefix: "PLC:TXI:HXR:VAC:L1"
     ffo_start: 1
     ffo_end: 1
     ff_start: 1
     ff_end: 50
 
-  - prefix: "PLC:TXI:LFE:OPTICS:"
+  - name: "TXI LFE Optics"
+    prefix: "PLC:TXI:LFE:OPTICS:"
     ffo_start: 1
     ffo_end: 1
     ff_start: 1

--- a/LFE_config.yml
+++ b/LFE_config.yml
@@ -10,6 +10,8 @@ dashboard_url: "http://ctl-logsrv01:3000/ctl/grafana/d/PQBzCnmMz/l-pmps-events?r
 fastfaults:
   - name: "LFE Arbiter"
     prefix: "PMPS:LFE:"
+    ffo_desc: ["PMPS System", "Spare"]
+    ffo_veto: ["None", "None"]
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
@@ -17,6 +19,8 @@ fastfaults:
 
   - name: "LFE Vacuum"
     prefix: "PLC:LFE:VAC:"
+    ffo_desc: ["Upstream of ST1L0", "Downstream of ST1L0", "Fast shutter"]
+    ffo_veto: ["None", "ST1L0 IN", "None"]
     ffo_start: 1
     ffo_end: 3
     ff_start: 1
@@ -24,6 +28,8 @@ fastfaults:
 
   - name: "LFE GEM"
     prefix: "PLC:LFE:GEM:"
+    ffo_desc: ["GEM Valves", "AT1L0"]
+    ffo_veto: ["None", "None"]
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
@@ -31,6 +37,8 @@ fastfaults:
 
   - name: "LFE CC Motion"
     prefix: "PLC:LFE:MOTION:"
+    ffo_desc: ["LFE States", "AT2L0"]
+    ffo_veto: ["None", "None"]
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
@@ -38,6 +46,8 @@ fastfaults:
 
   - name: "LFE Optics"
     prefix: "PLC:LFE:OPTICS:"
+    ffo_desc: ["All LFE Optics", "Spare"]
+    ffo_veto: ["None", "None"]
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
@@ -45,6 +55,8 @@ fastfaults:
 
   - name: "XRT Optics"
     prefix: "PLC:XRT:OPTICS:"
+    ffo_desc: ["Coating Checks", "MR1L3 States"]
+    ffo_veto: ["ST1L0 IN", "MR1L3 OUT"]
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
@@ -52,6 +64,8 @@ fastfaults:
 
   - name: "TXI CC Motion"
     prefix: "PLC:TXI:MOTION:"
+    ffo_desc: ["ALL TXI HXR Motion"]
+    ffo_veto: ["ST1L1 IN"]
     ffo_start: 1
     ffo_end: 1
     ff_start: 1
@@ -59,6 +73,8 @@ fastfaults:
 
   - name: "TXI LFE VAC"
     prefix: "PLC:TXI:HXR:VAC:"
+    ffo_desc: ["ALL TXI HXR Vac"]
+    ffo_veto: ["ST1L1 IN"]
     ffo_start: 1
     ffo_end: 1
     ff_start: 1
@@ -66,6 +82,8 @@ fastfaults:
 
   - name: "TXI L1 VAC"
     prefix: "PLC:TXI:HXR:VAC:L1"
+    ffo_desc: ["Planned"]
+    ffo_veto: ["None"]
     ffo_start: 1
     ffo_end: 1
     ff_start: 1
@@ -73,6 +91,8 @@ fastfaults:
 
   - name: "TXI LFE Optics"
     prefix: "PLC:TXI:LFE:OPTICS:"
+    ffo_desc: ["All TXI HXR Optics"]
+    ffo_veto: ["None"]
     ffo_start: 1
     ffo_end: 1
     ff_start: 1

--- a/arbiter_outputs.py
+++ b/arbiter_outputs.py
@@ -63,24 +63,32 @@ class ArbiterOutputs(Display):
             prefix = ff.get('prefix')
             ffo_start = ff.get('ffo_start')
             ffo_end = ff.get('ffo_end')
+            ff_start = ff.get('ff_start')
+            ff_end = ff.get('ff_end')
             ff_count = ff.get('ff_end', -1) - ff.get('ff_start', 0) + 1
 
             ffos_zfill = len(str(ffo_end)) + 1
 
             entries = range(ffo_start, ffo_end+1)
 
-            template = 'templates/arbiter_outputs_entry.ui'
+            template = 'templates/arbiter_outputs_entry.py'
             for _ffo in entries:
                 s_ffo = str(_ffo).zfill(ffos_zfill)
-                macros = dict(index=count, P=prefix, FFO=s_ffo, NAME=name, FFO_INDEX=_ffo, FF_COUNT=ff_count)
+                macros = dict(
+                    index=count,
+                    ff_start=ff_start,
+                    ff_end=ff_end,
+                    P=prefix,
+                    FFO=s_ffo,
+                    NAME=name,
+                    FFO_INDEX=_ffo,
+                    FF_COUNT=ff_count,
+                )
                 widget = PyDMEmbeddedDisplay(parent=outs_container)
                 widget.macros = json.dumps(macros)
                 widget.filename = template
                 widget.disconnectWhenHidden = False
                 widget.setMinimumHeight(40)
-                #widget.loadWhenShown = False
-                #widget.embedded_widget.ui.name_label.setText(f"{name} FFO #{_ffo}")
-                #widget.embedded_widget.ui.conf_count_label.setText(str(ff_count))
                 outs_container.layout().addWidget(widget)
                 count += 1
 

--- a/arbiter_outputs.py
+++ b/arbiter_outputs.py
@@ -59,9 +59,11 @@ class ArbiterOutputs(Display):
             return
         count = 0
         for ff in ffs:
+            name = ff.get('name')
             prefix = ff.get('prefix')
             ffo_start = ff.get('ffo_start')
             ffo_end = ff.get('ffo_end')
+            ff_count = ff.get('ff_end', -1) - ff.get('ff_start', 0) + 1
 
             ffos_zfill = len(str(ffo_end)) + 1
 
@@ -70,14 +72,18 @@ class ArbiterOutputs(Display):
             template = 'templates/arbiter_outputs_entry.ui'
             for _ffo in entries:
                 s_ffo = str(_ffo).zfill(ffos_zfill)
-                macros = dict(index=count, P=prefix, FFO=s_ffo)
+                macros = dict(index=count, P=prefix, FFO=s_ffo, NAME=name, FFO_INDEX=_ffo, FF_COUNT=ff_count)
                 widget = PyDMEmbeddedDisplay(parent=outs_container)
                 widget.macros = json.dumps(macros)
                 widget.filename = template
                 widget.disconnectWhenHidden = False
                 widget.setMinimumHeight(40)
+                #widget.loadWhenShown = False
+                #widget.embedded_widget.ui.name_label.setText(f"{name} FFO #{_ffo}")
+                #widget.embedded_widget.ui.conf_count_label.setText(str(ff_count))
                 outs_container.layout().addWidget(widget)
                 count += 1
+
         print(f'Added {count} arbiter outputs')
 
     def channels(self):

--- a/arbiter_outputs.py
+++ b/arbiter_outputs.py
@@ -88,6 +88,7 @@ class ArbiterOutputs(Display):
                 widget.macros = json.dumps(macros)
                 widget.filename = template
                 widget.disconnectWhenHidden = False
+                widget.loadWhenShown = False
                 widget.setMinimumHeight(40)
                 outs_container.layout().addWidget(widget)
                 count += 1

--- a/arbiter_outputs.py
+++ b/arbiter_outputs.py
@@ -70,9 +70,11 @@ class ArbiterOutputs(Display):
             ffos_zfill = len(str(ffo_end)) + 1
 
             entries = range(ffo_start, ffo_end+1)
+            ffo_desc = ff.get('ffo_desc', ['']*len(entries))
+            ffo_veto = ff.get('ffo_veto', ['']*len(entries))
 
             template = 'templates/arbiter_outputs_entry.py'
-            for _ffo in entries:
+            for _ffo, desc, veto in zip(entries, ffo_desc, ffo_veto):
                 s_ffo = str(_ffo).zfill(ffos_zfill)
                 macros = dict(
                     index=count,
@@ -83,6 +85,8 @@ class ArbiterOutputs(Display):
                     NAME=name,
                     FFO_INDEX=_ffo,
                     FF_COUNT=ff_count,
+                    DESC=desc,
+                    VETO=veto,
                 )
                 widget = PyDMEmbeddedDisplay(parent=outs_container)
                 widget.macros = json.dumps(macros)

--- a/fast_faults.py
+++ b/fast_faults.py
@@ -128,6 +128,7 @@ class FastFaults(Display):
         options = [
             {'name': 'ok', 'channel': 'ca://${P}FFO:${FFO}:FF:${FF}:OK_RBV'},
             {'name': 'beampermitted', 'channel': 'ca://${P}FFO:${FFO}:FF:${FF}:BeamPermitted_RBV'},
+            {'name': 'vetoed', 'channel': 'ca://${P}FFO:${FFO}:EnableVeto_RBV'},
             {'name': 'bypassed', 'channel': 'ca://${P}FFO:${FFO}:FF:${FF}:Ovrd:Active_RBV'}
         ]
         filters = []

--- a/fast_faults.py
+++ b/fast_faults.py
@@ -10,14 +10,6 @@ from pydm.widgets.datetime import PyDMDateTimeEdit, PyDMDateTimeLabel
 from qtpy import QtCore, QtWidgets
 
 
-def clear_channel(ch):
-    if ch:
-        try:
-            ch.disconnect()
-        except:
-            pass
-
-
 class VisibilityEmbedded(PyDMEmbeddedDisplay):
 
     def __init__(self, channel=None, *args, **kwargs):
@@ -27,7 +19,6 @@ class VisibilityEmbedded(PyDMEmbeddedDisplay):
         self.channel = None
         if channel:
             self.channel = PyDMChannel(channel, connection_slot=self.connection_changed)
-        self.destroyed.connect(functools.partial(clear_channel, channel))
 
     def connection_changed(self, status):
         self._connected = status
@@ -152,12 +143,6 @@ class FastFaults(Display):
             value_slot=self.update_time_delta,
         )
         self.dt_channel.connect()
-        self.destroyed.connect(
-            functools.partial(
-                clear_channel,
-                self.dt_channel,
-            )
-        )
 
     def update_min_times(self):
         current_time = QtCore.QDateTime.currentSecsSinceEpoch()

--- a/fast_faults.ui
+++ b/fast_faults.ui
@@ -198,6 +198,50 @@
           </widget>
          </item>
          <item>
+          <widget class="QGroupBox" name="ff_filter_gb_vetoed">
+           <property name="title">
+            <string>Filter By: Veto State</string>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_9">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QComboBox" name="ff_filter_cb_vetoed">
+              <item>
+               <property name="text">
+                <string>False</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>True</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
           <widget class="QGroupBox" name="ff_filter_gb_bypassed">
            <property name="title">
             <string>Filter By: Bypassed State</string>

--- a/plc_ioc_status.py
+++ b/plc_ioc_status.py
@@ -9,8 +9,6 @@ from pydm.widgets.channel import PyDMChannel
 from qtpy import QtWidgets
 from qtpy.QtGui import QColor
 
-from fast_faults import clear_channel
-
 
 class PLCIOCStatus(Display):
     _on_color = QColor(0, 255, 0)
@@ -23,13 +21,6 @@ class PLCIOCStatus(Display):
         self.ffs_count_map = {}
         self.ffs_label_map = {}
         self.setup_ui()
-        for ch in (
-            self.plc_status_ch,
-            self.plc_task1_vis_ch,
-            self.plc_task2_vis_ch,
-            self.plc_task3_vis_ch,
-        ):
-            self.destroyed.connect(functools.partial(clear_channel, ch))
 
     def setup_ui(self):
         self.setup_plc_ioc_status()

--- a/templates/arbiter_outputs_entry.py
+++ b/templates/arbiter_outputs_entry.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from pydm import Display
+from pydm.widgets.channel import PyDMChannel
+from qtpy.QtCore import QObject, QTimer, Signal
+
+
+class ArbiterRow(Display):
+    fault_counters: list[CounterElement]
+    faults: list[bool]
+    bypass_counters: list[CounterElement]
+    bypasses: list[bool]
+    in_use_counters: list[CounterElement]
+    in_uses: list[bool]
+    is_connected: list[bool]
+
+    def __init__(self, parent=None, args=None, macros=None):
+        super().__init__(parent=parent, args=args, macros=macros)
+        self.config = macros
+        self._channels = []
+        self.fault_counters = []
+        self.bypass_counters = []
+        self.in_use_counters = []
+        self.faults = []
+        self.bypasses = []
+        self.in_uses = []
+        self.is_connected = []
+        self.setup_ui()
+
+    def setup_ui(self):
+        self.setup_counters()
+
+    def setup_counters(self):
+        self.prefix = self.config["P"]
+        self.ffo = self.config["FFO"]
+        self.ff_start = self.config["ff_start"]
+        self.fault_num = self.ff_start
+        self.ff_end = self.config["ff_end"]
+        self.zfill = len(str(self.ff_end)) + 1
+        self.loop_count = 0
+
+        self.next_counter_soon()
+
+    def next_counter_soon(self):
+        self.setup_counter_timer = QTimer()
+        self.setup_counter_timer.singleShot(1, self.setup_next_counter)
+
+    def setup_next_counter(self):
+        fault_num_str = str(self.fault_num).zfill(self.zfill)
+        # Use the ok channel to get the faulting counts
+        fc = CounterElement(
+            pvname=f"ca://{self.prefix}FFO:{self.ffo}:FF:{fault_num_str}:OK_RBV",
+            index=self.loop_count,
+            value_cache=self.faults,
+            invert=True,
+        )
+        fc_dest = PyDMChannel(
+            address=f"loc://{self.prefix}{self.ffo}:FaultCount?type=int&init=0",
+            value_slot=self.new_fault_count,
+            value_signal=fc.value_sig,
+        )
+        self.fault_counters.append(fc)
+        self.faults.append(0)
+        fc_dest.connect()
+        self._channels.append(fc_dest)
+        fc_ch = fc.create_channel()
+        fc_ch.connect()
+        self._channels.append(fc_ch)
+
+        # Use the bypass channel to get the bypass counts
+        bc = CounterElement(
+            pvname=f"ca://{self.prefix}FFO:{self.ffo}:FF:{fault_num_str}:Ovrd:Active_RBV",
+            index=self.loop_count,
+            value_cache=self.bypasses,
+        )
+        bc_dest = PyDMChannel(
+            address=f"loc://{self.prefix}{self.ffo}:BypassCount?type=int&init=0",
+            value_slot=self.new_bypass_count,
+            value_signal=bc.value_sig,
+        )
+        self.bypass_counters.append(bc)
+        self.bypasses.append(0)
+        bc_dest.connect()
+        self._channels.append(bc_dest)
+        bc_ch = bc.create_channel()
+        bc_ch.connect()
+        self._channels.append(bc_ch)
+
+        # Use the in_use channel to get the registered and connected counts
+        ic = CounterElement(
+            pvname=f"ca://{self.prefix}FFO:{self.ffo}:FF:{fault_num_str}:Info:InUse_RBV",
+            index=self.loop_count,
+            value_cache=self.in_uses,
+            conn_cache=self.is_connected,
+        )
+        ic_dest = PyDMChannel(
+            address=f"loc://{self.prefix}{self.ffo}:RegCount?type=int&init=0",
+            value_slot=self.show_loc_connected,
+            value_signal=ic.value_sig,
+        )
+        ic_conn_dest = PyDMChannel(
+            address=f"loc://{self.prefix}{self.ffo}:ConnCount?type=int&init=0",
+            value_slot=self.show_loc_connected,
+            value_signal=ic.conn_sig,
+        )
+        self.in_use_counters.append(ic)
+        self.in_uses.append(0)
+        self.is_connected.append(0)
+        ic_dest.connect()
+        ic_conn_dest.connect()
+        self._channels.append(ic_dest)
+        self._channels.append(ic_conn_dest)
+        ic_ch = ic.create_channel()
+        ic_ch.connect()
+        self._channels.append(ic_ch)
+
+        self.loop_count += 1
+        self.fault_num += 1
+
+        if self.fault_num <= self.ff_end:
+            self.next_counter_soon()
+
+    def show_loc_connected(self, *args, **kwargs):
+        ...
+
+    def new_fault_count(self, count: int):
+        if count:
+            self.ui.fault_label.alarm_severity_changed(2)
+        else:
+            self.ui.fault_label.alarm_severity_changed(0)
+
+    def new_bypass_count(self, count: int):
+        if count:
+            self.ui.bypass_label.alarm_severity_changed(2)
+        else:
+            self.ui.bypass_label.alarm_severity_changed(0)
+
+    def channels(self):
+        return self._channels
+
+    def ui_filename(self):
+        return 'arbiter_outputs_entry.ui'
+
+
+class CounterElement(QObject):
+    value_sig = Signal(int)
+    conn_sig = Signal(int)
+
+    def __init__(
+        self,
+        pvname: str,
+        index: int,
+        value_cache: list[int],
+        conn_cache: list[int] | None = None,
+        invert: bool = False,
+        parent: QObject | None = None,
+    ):
+        super().__init__(parent=parent)
+        self.pvname = pvname
+        self.index = index
+        self.value_cache = value_cache
+        self.conn_cache = conn_cache
+        self.invert = invert
+
+    def create_channel(self) -> PyDMChannel:
+        if self.conn_cache is None:
+            return PyDMChannel(
+                address=self.pvname,
+                value_slot=self.new_value,
+            )
+        else:
+            return PyDMChannel(
+                address=self.pvname,
+                value_slot=self.new_value,
+                connection_slot=self.new_conn,
+            )
+
+    def new_value(self, value: int) -> None:
+        if self.invert:
+            value = 1 - value
+        self.value_cache[self.index] = value
+        self.value_sig.emit(sum(self.value_cache))
+
+    def new_conn(self, conn: int) -> None:
+        self.conn_cache[self.index] = conn
+        self.conn_sig.emit(sum(self.conn_cache))

--- a/templates/arbiter_outputs_entry.py
+++ b/templates/arbiter_outputs_entry.py
@@ -1,3 +1,10 @@
+"""
+Embedded pydm screen for a single row in the Arbiter Outputs table.
+
+Rather than putting this functionality into arbiter_outputs.py and reaching
+into the embedded widgets, it is cleaner to include it here and apply the
+behavior to the ui file in a more natural way.
+"""
 from __future__ import annotations
 
 from pydm import Display
@@ -6,6 +13,16 @@ from qtpy.QtCore import QObject, QTimer, Signal
 
 
 class ArbiterRow(Display):
+    """
+    PyDM display that represents one row in the Arbiter Outputs table.
+
+    This class is responsible for adding PyDM connections to all of the
+    fast fault PVs and keeping track of their status via counting.
+
+    The ui file this class uses has additional widgets for indicator
+    lights and text display that are paramterized via macros like normal
+    code-free pydm screens.
+    """
     fault_summaries: list[FaultSummary]
     fault_counters: list[CounterElement]
     faults: list[bool]
@@ -29,10 +46,22 @@ class ArbiterRow(Display):
         self.is_connected = []
         self.setup_ui()
 
-    def setup_ui(self):
+    def setup_ui(self) -> None:
+        """Standard-use catch-all method name for qt startup actions."""
         self.setup_counters()
 
-    def setup_counters(self):
+    def setup_counters(self) -> None:
+        """
+        Connect to the fast fault PVs and initialize the counters.
+
+        This sets up the initial conditions for the async chain of
+        next_counter_soon calls that split up the widget setup into
+        multiple qt events. It is implemented in this way so that the
+        render events and the user's input events can happen during
+        setup while this tab loads in the background.
+
+        You can think of this like a fancy for loop.
+        """
         self.prefix = self.config["P"]
         self.ffo = self.config["FFO"]
         self.ff_start = self.config["ff_start"]
@@ -43,11 +72,37 @@ class ArbiterRow(Display):
 
         self.next_counter_soon()
 
-    def next_counter_soon(self):
+    def next_counter_soon(self) -> None:
+        """
+        Creates a counter by calling setup_next_counter on the qt event queue.
+
+        Combined with setup_next_counter, this starts or continues a chain of
+        counter instantiations that ends when we exhaust our list of
+        configured PVs.
+
+        The event will happen 1ms after this method call to give plenty
+        of time for user input and rendering events, while not being so long
+        as to drag out the chain of initialization.
+
+        A reference is held to the QTimer to prevent garbage collection,
+        but I'm not entirely sure this is needed.
+        """
         self.setup_counter_timer = QTimer()
         self.setup_counter_timer.singleShot(1, self.setup_next_counter)
 
-    def setup_next_counter(self):
+    def setup_next_counter(self) -> None:
+        """
+        Adds one additional counting source, then calls next_counter_soon.
+
+        Combined with next_counter_soon, this starts or continues a chain of
+        counter instantiations that ends when we exhaust our list of
+        configured PVs.
+
+        Each counting source is a group of PyDM channels that consume
+        EPICS PVs with information pertaining to fast faults.
+        These are then aggregated with all the other counting sources to get
+        a total count of e.g. the number of faulting channels, etc.
+        """
         fault_num_str = str(self.fault_num).zfill(self.zfill)
         # Use the bypass channel to get the bypass counts
         bypass_counter = CounterElement(
@@ -99,7 +154,7 @@ class ArbiterRow(Display):
         self._channels.append(ic_ch)
 
         # Combine the ok and in_use channels to get the fault counts
-        # We are fauling if ok=False and in_use=True
+        # We are faulting if ok=False and in_use=True
         # Summarize this as a combined local channel
         fault_summary = FaultSummary(
             ok_pvname=f"ca://{self.prefix}FFO:{self.ffo}:FF:{fault_num_str}:OK_RBV",
@@ -145,28 +200,82 @@ class ArbiterRow(Display):
             self.next_counter_soon()
 
     def show_loc_connected(self, *args, **kwargs):
+        """
+        No-op slot to put on loc:// channels so that they show as connected.
+
+        Otherwise, they can show as disconnected even if the value updates
+        properly.
+        """
         ...
 
     def new_fault_count(self, count: int):
+        """
+        Slot to show a "major" alarm when the total fault count is nonzero.
+        """
         if count:
             self.ui.fault_label.alarm_severity_changed(2)
         else:
             self.ui.fault_label.alarm_severity_changed(0)
 
     def new_bypass_count(self, count: int):
+        """
+        Slot to show a "minor" alarm when the total bypass count is nonzero.
+        """
         if count:
             self.ui.bypass_label.alarm_severity_changed(1)
         else:
             self.ui.bypass_label.alarm_severity_changed(0)
 
     def channels(self):
+        """
+        Callable method to return a list of open PyDMChannel instances.
+
+        This is sometimes used by PyDM to find channels to clean up.
+        """
         return self._channels
 
     def ui_filename(self):
+        """
+        Return the name of the ui file to load for PyDM.
+        """
         return 'arbiter_outputs_entry.ui'
 
 
 class CounterElement(QObject):
+    """
+    A helper object for including one channel's value in the shared counts.
+
+    Each data source that contributes to a count should have one
+    CounterElement that points to the unique channel address and to a shared
+    value list and optionally a shared connection list.
+
+    Then, whenever that value source updates (and optionally when the
+    connection state changes), this class will update the shared list
+    and emit the total count from its value_sig (and optionally the
+    conn_sig too.) This design was chosen to avoid race conditions with
+    counters and counter statuses. For example, if two counters increment at
+    the same time, they will both emit the correct sum regardless of the
+    order they reach the emit method call.
+
+    The data source is expected to supply integers that are either 1 or 0.
+
+    Parameters
+    ----------
+    pvname : str
+        The PyDM channel address to use as the source of data.
+    index : int
+        The index in the various caches that this counter should write
+        its state to.
+    value_cache : list of int
+        A shared list of all the values from all of the different counter
+        elements that contribute to the shared count.
+    conn_cache : list of int, optional
+        If provided, this is the same as the value_cache except it is used
+        to track connection status.
+    parent : QObject, optional
+        Standard qt parent argument. If provided, it makes this object
+        a child object of the parent.
+    """
     value_sig = Signal(int)
     conn_sig = Signal(int)
 
@@ -185,6 +294,17 @@ class CounterElement(QObject):
         self.conn_cache = conn_cache
 
     def create_channel(self) -> PyDMChannel:
+        """
+        Create and return the PyDMChannel object.
+
+        Once connected, this channel will start collecting values
+        for the shared lists and this object's signals will be
+        active.
+
+        It is best to create and connect the channels only after
+        downstream consumers are ready to use the values from value_sig
+        and conn_sig.
+        """
         if self.conn_cache is None:
             return PyDMChannel(
                 address=self.pvname,
@@ -198,15 +318,44 @@ class CounterElement(QObject):
             )
 
     def new_value(self, value: int) -> None:
+        """
+        When a new value is recieved, stash it and emit the total count.
+        """
         self.value_cache[self.index] = value
         self.value_sig.emit(sum(self.value_cache))
 
     def new_conn(self, conn: int) -> None:
+        """
+        When a new connection state is recieved, stash it and emit the total count.
+        """
         self.conn_cache[self.index] = conn
         self.conn_sig.emit(sum(self.conn_cache))
 
 
 class FaultSummary(QObject):
+    """
+    Summarize the fault state of a single fast fault.
+
+    This is a combination of the OK signal and the IN_USE signal.
+    A signal is faulting if it is "IN_USE" but "NOT OK".
+
+    This is important because all faults that are "NOT IN_USE" are also
+    "NOT OK" by default, creating a lot of false positives for the fault
+    counter if we neglect to consider the IN_USE signal.
+
+    Parameters
+    ----------
+    ok_pvname : str
+        The PyDM channel associated with the "OK" fault signal, which is
+        1 when the condition is OK and 0 when we are faulting.
+    in_use_pvname : str
+        The PyDM channel associated with the "IN_USE" fault signal,
+        which is 1 when the fault's OK state is valid and is 0 when the
+        fault's OK state is invalid.
+    parent : QObject, optional
+        Standard qt parent argument. If provided, it makes this object
+        a child object of the parent.
+    """
     value_sig = Signal(int)
     is_ok: int
     is_in_use: int
@@ -224,6 +373,12 @@ class FaultSummary(QObject):
         self.is_in_use = 0
 
     def create_channels(self) -> tuple[PyDMChannel, PyDMChannel]:
+        """
+        Return two channels for the OK and IN_USE signals respectively.
+
+        Once connected, these channels will start collecting values
+        to combine for the aggregate value_sig output.
+        """
         return PyDMChannel(
             address=self.ok_pvname,
             value_slot=self.new_ok,
@@ -233,14 +388,23 @@ class FaultSummary(QObject):
         )
 
     def new_ok(self, value: int):
+        """
+        When we recieve a new value from the OK signal, stash and update.
+        """
         self.is_ok = value
         self.new_fault()
 
     def new_in_use(self, value: int):
+        """
+        When we recieve a new value from the IN_USE signal, stash and update.
+        """
         self.is_in_use = value
         self.new_fault()
 
     def new_fault(self):
+        """
+        Update consumers of value_sig with the current fault state.
+        """
         if self.is_in_use:
             self.value_sig.emit(1 - self.is_ok)
         else:

--- a/templates/arbiter_outputs_entry.ui
+++ b/templates/arbiter_outputs_entry.ui
@@ -233,7 +233,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="fault_count_label">
+    <widget class="PyDMLabel" name="fault_label">
      <property name="minimumSize">
       <size>
        <width>100</width>
@@ -246,16 +246,40 @@
        <height>16777215</height>
       </size>
      </property>
-     <property name="text">
+     <property name="toolTip">
       <string/>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
+     </property>
+     <property name="precision" stdset="0">
+      <number>0</number>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="precisionFromPV" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="PyDMToolTip" stdset="0">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>loc://${P}${FFO}:FaultCount</string>
+     </property>
+     <property name="enableRichText" stdset="0">
+      <bool>false</bool>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="bypass_count_label">
+    <widget class="PyDMLabel" name="bypass_label">
      <property name="minimumSize">
       <size>
        <width>100</width>
@@ -268,16 +292,40 @@
        <height>16777215</height>
       </size>
      </property>
-     <property name="text">
+     <property name="toolTip">
       <string/>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
+     </property>
+     <property name="precision" stdset="0">
+      <number>0</number>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="precisionFromPV" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="PyDMToolTip" stdset="0">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>loc://${P}${FFO}:BypassCount</string>
+     </property>
+     <property name="enableRichText" stdset="0">
+      <bool>false</bool>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="reg_count_label">
+    <widget class="PyDMLabel" name="PyDMLabel_3">
      <property name="minimumSize">
       <size>
        <width>100</width>
@@ -290,16 +338,40 @@
        <height>16777215</height>
       </size>
      </property>
-     <property name="text">
+     <property name="toolTip">
       <string/>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
+     </property>
+     <property name="precision" stdset="0">
+      <number>0</number>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="precisionFromPV" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="PyDMToolTip" stdset="0">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>loc://${P}${FFO}:RegCount</string>
+     </property>
+     <property name="enableRichText" stdset="0">
+      <bool>false</bool>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="conn_count_label">
+    <widget class="PyDMLabel" name="PyDMLabel_4">
      <property name="minimumSize">
       <size>
        <width>100</width>
@@ -312,11 +384,35 @@
        <height>16777215</height>
       </size>
      </property>
-     <property name="text">
+     <property name="toolTip">
       <string/>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
+     </property>
+     <property name="precision" stdset="0">
+      <number>0</number>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="precisionFromPV" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="PyDMToolTip" stdset="0">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>loc://${P}${FFO}:ConnCount</string>
+     </property>
+     <property name="enableRichText" stdset="0">
+      <bool>false</bool>
      </property>
     </widget>
    </item>
@@ -358,6 +454,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
   <customwidget>
    <class>PyDMByteIndicator</class>
    <extends>QWidget</extends>

--- a/templates/arbiter_outputs_entry.ui
+++ b/templates/arbiter_outputs_entry.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>660</width>
+    <width>936</width>
     <height>40</height>
    </rect>
   </property>
@@ -25,7 +25,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,2">
+  <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0,0,0,0,0,0">
    <property name="spacing">
     <number>0</number>
    </property>
@@ -41,6 +41,28 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
+   <item>
+    <widget class="QLabel" name="name_label">
+     <property name="minimumSize">
+      <size>
+       <width>160</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>160</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>${NAME} FFO #${FFO_INDEX}</string>
+     </property>
+     <property name="indent">
+      <number>5</number>
+     </property>
+    </widget>
+   </item>
    <item alignment="Qt::AlignVCenter">
     <widget class="PyDMByteIndicator" name="PyDMByteIndicator_3">
      <property name="enabled">
@@ -70,6 +92,13 @@
      <property name="channel" stdset="0">
       <string>ca://${P}FFO:${FFO}:FaultHWO_RBV</string>
      </property>
+     <property name="offColor" stdset="0">
+      <color>
+       <red>255</red>
+       <green>0</green>
+       <blue>0</blue>
+      </color>
+     </property>
      <property name="showLabels" stdset="0">
       <bool>false</bool>
      </property>
@@ -79,54 +108,256 @@
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="label">
+    <widget class="PyDMByteIndicator" name="PyDMByteIndicator_4">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>80</width>
+       <height>32</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>80</width>
+       <height>32</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${P}FFO:${FFO}:EnableVeto_RBV</string>
+     </property>
+     <property name="onColor" stdset="0">
+      <color>
+       <red>0</red>
+       <green>150</green>
+       <blue>255</blue>
+      </color>
+     </property>
+     <property name="offColor" stdset="0">
+      <color>
+       <red>100</red>
+       <green>100</green>
+       <blue>100</blue>
+      </color>
+     </property>
+     <property name="showLabels" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="circles" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMByteIndicator" name="PyDMByteIndicator_5">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>80</width>
+       <height>32</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>80</width>
+       <height>32</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="PyDMToolTip" stdset="0">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${P}FFO:${FFO}:RegistrationFailure_RBV</string>
+     </property>
+     <property name="onColor" stdset="0">
+      <color>
+       <red>255</red>
+       <green>0</green>
+       <blue>0</blue>
+      </color>
+     </property>
+     <property name="offColor" stdset="0">
+      <color>
+       <red>100</red>
+       <green>100</green>
+       <blue>100</blue>
+      </color>
+     </property>
+     <property name="showLabels" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="bigEndian" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="circles" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="numBits" stdset="0">
+      <number>1</number>
+     </property>
+     <property name="shift" stdset="0">
+      <number>0</number>
+     </property>
+     <property name="labels" stdset="0">
+      <stringlist>
+       <string>Bit 0</string>
+      </stringlist>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="fault_count_label">
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
-       <height>45</height>
+       <width>100</width>
+       <height>16777215</height>
       </size>
      </property>
      <property name="text">
-      <string>${P}FFO:${FFO}:FaultHWO_RBV</string>
+      <string/>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="PyDMLabel" name="PyDMLabel_7">
-     <property name="enabled">
-      <bool>false</bool>
+    <widget class="QLabel" name="bypass_count_label">
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>0</height>
+      </size>
      </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+     <property name="maximumSize">
+      <size>
+       <width>100</width>
+       <height>16777215</height>
+      </size>
      </property>
-     <property name="toolTip">
+     <property name="text">
       <string/>
      </property>
-     <property name="showUnits" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${P}FFO:${FFO}:FaultHWO_RBV.DESC</string>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
      </property>
     </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="reg_count_label">
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>100</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="conn_count_label">
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>100</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="conf_count_label">
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>100</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>${FF_COUNT}</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>PyDMLabel</class>
-   <extends>QLabel</extends>
-   <header>pydm.widgets.label</header>
-  </customwidget>
   <customwidget>
    <class>PyDMByteIndicator</class>
    <extends>QWidget</extends>

--- a/templates/arbiter_outputs_entry.ui
+++ b/templates/arbiter_outputs_entry.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>936</width>
+    <width>1309</width>
     <height>40</height>
    </rect>
   </property>
@@ -25,7 +25,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0,0,0,0,0,0">
+  <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0,0,0,0,0,0,0,0">
    <property name="spacing">
     <number>0</number>
    </property>
@@ -57,6 +57,28 @@
      </property>
      <property name="text">
       <string>${NAME} FFO #${FFO_INDEX}</string>
+     </property>
+     <property name="indent">
+      <number>5</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="name_label_2">
+     <property name="minimumSize">
+      <size>
+       <width>200</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>${DESC}</string>
      </property>
      <property name="indent">
       <number>5</number>
@@ -159,76 +181,24 @@
     </widget>
    </item>
    <item>
-    <widget class="PyDMByteIndicator" name="PyDMByteIndicator_5">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
+    <widget class="QLabel" name="name_label_3">
      <property name="minimumSize">
       <size>
-       <width>80</width>
-       <height>32</height>
+       <width>200</width>
+       <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>80</width>
-       <height>32</height>
+       <width>200</width>
+       <height>16777215</height>
       </size>
      </property>
-     <property name="toolTip">
-      <string/>
+     <property name="text">
+      <string>${VETO}</string>
      </property>
-     <property name="alarmSensitiveContent" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="alarmSensitiveBorder" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="PyDMToolTip" stdset="0">
-      <string/>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${P}FFO:${FFO}:RegistrationFailure_RBV</string>
-     </property>
-     <property name="onColor" stdset="0">
-      <color>
-       <red>255</red>
-       <green>0</green>
-       <blue>0</blue>
-      </color>
-     </property>
-     <property name="offColor" stdset="0">
-      <color>
-       <red>100</red>
-       <green>100</green>
-       <blue>100</blue>
-      </color>
-     </property>
-     <property name="showLabels" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="bigEndian" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="circles" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="numBits" stdset="0">
-      <number>1</number>
-     </property>
-     <property name="shift" stdset="0">
-      <number>0</number>
-     </property>
-     <property name="labels" stdset="0">
-      <stringlist>
-       <string>Bit 0</string>
-      </stringlist>
+     <property name="indent">
+      <number>5</number>
      </property>
     </widget>
    </item>
@@ -435,6 +405,80 @@
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMByteIndicator" name="PyDMByteIndicator_5">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>32</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>100</width>
+       <height>32</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="PyDMToolTip" stdset="0">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${P}FFO:${FFO}:RegistrationFailure_RBV</string>
+     </property>
+     <property name="onColor" stdset="0">
+      <color>
+       <red>255</red>
+       <green>0</green>
+       <blue>0</blue>
+      </color>
+     </property>
+     <property name="offColor" stdset="0">
+      <color>
+       <red>100</red>
+       <green>100</green>
+       <blue>100</blue>
+      </color>
+     </property>
+     <property name="showLabels" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="bigEndian" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="circles" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="numBits" stdset="0">
+      <number>1</number>
+     </property>
+     <property name="shift" stdset="0">
+      <number>0</number>
+     </property>
+     <property name="labels" stdset="0">
+      <stringlist>
+       <string>Bit 0</string>
+      </stringlist>
      </property>
     </widget>
    </item>

--- a/templates/arbiter_outputs_header.ui
+++ b/templates/arbiter_outputs_header.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>677</width>
+    <width>944</width>
     <height>34</height>
    </rect>
   </property>
@@ -48,10 +48,44 @@
     <number>0</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,0,2,0">
+    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,0,0,0,0,0,0,0,0">
      <property name="spacing">
       <number>0</number>
      </property>
+     <item>
+      <widget class="QLabel" name="label_9">
+       <property name="minimumSize">
+        <size>
+         <width>160</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>160</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Output</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+       <property name="wordWrap">
+        <bool>false</bool>
+       </property>
+       <property name="indent">
+        <number>20</number>
+       </property>
+      </widget>
+     </item>
      <item>
       <widget class="QLabel" name="label_7">
        <property name="minimumSize">
@@ -73,7 +107,7 @@
         </font>
        </property>
        <property name="text">
-        <string>Value</string>
+        <string>Fault</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
@@ -84,27 +118,17 @@
       </widget>
      </item>
      <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>30</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_5">
+      <widget class="QLabel" name="label_8">
        <property name="minimumSize">
         <size>
-         <width>250</width>
+         <width>80</width>
          <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
         </size>
        </property>
        <property name="font">
@@ -114,20 +138,29 @@
         </font>
        </property>
        <property name="text">
-        <string>PV</string>
+        <string>Veto</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="wordWrap">
+        <bool>false</bool>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_6">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
+      <widget class="QLabel" name="label_10">
+       <property name="minimumSize">
+        <size>
+         <width>80</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
        </property>
        <property name="font">
         <font>
@@ -136,10 +169,165 @@
         </font>
        </property>
        <property name="text">
-        <string>Description</string>
+        <string>Error</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="wordWrap">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_13">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Faulting</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="wordWrap">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_15">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Bypassed</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="wordWrap">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_11">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Registered</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="wordWrap">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_12">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Connected</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="wordWrap">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_14">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Configured</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
        </property>
        <property name="wordWrap">
         <bool>false</bool>

--- a/templates/arbiter_outputs_header.ui
+++ b/templates/arbiter_outputs_header.ui
@@ -107,7 +107,7 @@
         </font>
        </property>
        <property name="text">
-        <string>Fault</string>
+        <string>Beam Ok</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>

--- a/templates/arbiter_outputs_header.ui
+++ b/templates/arbiter_outputs_header.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>944</width>
+    <width>1306</width>
     <height>34</height>
    </rect>
   </property>
@@ -48,7 +48,7 @@
     <number>0</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,0,0,0,0,0,0,0,0">
+    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,0,0,0,0,0,0,0,0,0,0">
      <property name="spacing">
       <number>0</number>
      </property>
@@ -74,6 +74,40 @@
        </property>
        <property name="text">
         <string>Output</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+       <property name="wordWrap">
+        <bool>false</bool>
+       </property>
+       <property name="indent">
+        <number>20</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_16">
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>200</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Description</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -149,16 +183,16 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_10">
+      <widget class="QLabel" name="label_17">
        <property name="minimumSize">
         <size>
-         <width>80</width>
+         <width>200</width>
          <height>0</height>
         </size>
        </property>
        <property name="maximumSize">
         <size>
-         <width>80</width>
+         <width>200</width>
          <height>16777215</height>
         </size>
        </property>
@@ -169,13 +203,16 @@
         </font>
        </property>
        <property name="text">
-        <string>Error</string>
+        <string>Veto Condition</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignCenter</set>
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
        </property>
        <property name="wordWrap">
         <bool>false</bool>
+       </property>
+       <property name="indent">
+        <number>20</number>
        </property>
       </widget>
      </item>
@@ -325,6 +362,37 @@
        </property>
        <property name="text">
         <string>Configured</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="wordWrap">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_10">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>PLC Error</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>

--- a/templates/fastfaults_entry.ui
+++ b/templates/fastfaults_entry.ui
@@ -50,7 +50,7 @@
    <item>
     <widget class="PyDMLabel" name="DeviceName">
      <property name="enabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -81,7 +81,7 @@
    <item>
     <widget class="PyDMLabel" name="TypeCode">
      <property name="enabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -137,7 +137,7 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>274</width>
+        <width>234</width>
         <height>58</height>
        </rect>
       </property>
@@ -220,7 +220,7 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>274</width>
+        <width>234</width>
         <height>58</height>
        </rect>
       </property>
@@ -275,7 +275,7 @@
    <item>
     <widget class="PyDMByteIndicator" name="FFOk">
      <property name="enabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -313,7 +313,7 @@
    <item>
     <widget class="PyDMPushButton" name="PyDMPushButton">
      <property name="enabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -344,7 +344,7 @@
    <item>
     <widget class="PyDMByteIndicator" name="FFBeamOk">
      <property name="enabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -380,9 +380,70 @@
     </widget>
    </item>
    <item>
+    <widget class="PyDMByteIndicator" name="VetoIndicator">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>80</width>
+       <height>32</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>80</width>
+       <height>32</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="PyDMToolTip" stdset="0">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${P}FFO:${FFO}:EnableVeto_RBV</string>
+     </property>
+     <property name="onColor" stdset="0">
+      <color>
+       <red>0</red>
+       <green>150</green>
+       <blue>255</blue>
+      </color>
+     </property>
+     <property name="showLabels" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="bigEndian" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="circles" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="numBits" stdset="0">
+      <number>1</number>
+     </property>
+     <property name="shift" stdset="0">
+      <number>0</number>
+     </property>
+     <property name="labels" stdset="0">
+      <stringlist>
+       <string>Bit 0</string>
+      </stringlist>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="PyDMByteIndicator" name="BypassIndicator">
      <property name="enabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -536,7 +597,7 @@
    <item>
     <widget class="PyDMPushButton" name="BypassActivate">
      <property name="enabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="minimumSize">
       <size>
@@ -587,7 +648,7 @@ color: rgb(0, 0, 0);</string>
    <item>
     <widget class="PyDMPushButton" name="BypassDeactivate">
      <property name="enabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="minimumSize">
       <size>

--- a/templates/fastfaults_header.ui
+++ b/templates/fastfaults_header.ui
@@ -258,6 +258,34 @@
       </widget>
      </item>
      <item>
+      <widget class="QLabel" name="label_9">
+       <property name="minimumSize">
+        <size>
+         <width>80</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Veto</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QLabel" name="label_3">
        <property name="minimumSize">
         <size>

--- a/utils.py
+++ b/utils.py
@@ -59,7 +59,7 @@ class BackCompat(QtCore.QObject):
         """
         Helper for proper channel cleanup.
         """
-        return self._channels()
+        return self._channels
 
     def add_alternate_channel(self, widget: PyDMWidget, channel: str) -> None:
         """

--- a/utils.py
+++ b/utils.py
@@ -54,9 +54,6 @@ class BackCompat(QtCore.QObject):
         # This otherwise requires a full "widget" and is annoying
         # I'm not 100% sure if this works or not or if that matters
         self._channels = []
-        self.destroyed.connect(
-            functools.partial(_backcompat_destroyed, self.channels)
-        )
 
     def channels(self) -> list[PyDMChannel]:
         """
@@ -132,14 +129,3 @@ class BackCompat(QtCore.QObject):
             widget=widget,
             channel=widget.channel.replace("eVRanges", "PhotonEnergyRanges")
         )
-
-
-def _backcompat_destroyed(channels: Callable[[], list[PyDMChannel]]) -> None:
-    """
-    Some cleanup stolen from PyDM
-
-    See PyDM.widgets.base.widget_destroyed
-    """
-    for ch in channels():
-        if ch:
-            ch.disconnect(destroying=True)

--- a/widgets.py
+++ b/widgets.py
@@ -2,7 +2,7 @@ import functools
 import weakref
 from typing import Iterable
 
-from pydm.widgets.base import PyDMPrimitiveWidget, widget_destroyed
+from pydm.widgets.base import PyDMPrimitiveWidget
 from pydm.widgets.byte import PyDMByteIndicator
 from pydm.widgets.channel import PyDMChannel
 from pydm.widgets.label import PyDMLabel
@@ -53,10 +53,6 @@ class UndulatorWidget(QtWidgets.QWidget, PyDMPrimitiveWidget):
         self._connections = dict()
         self._forward_texture = None
         self._backward_texture = None
-        self.destroyed.connect(
-            functools.partial(widget_destroyed, self.channels,
-                              weakref.ref(self))
-        )
 
     @QtCore.Property(str)
     def prefix(self):
@@ -251,11 +247,6 @@ class UndulatorListWidget(QtWidgets.QWidget, PyDMPrimitiveWidget):
         self._backward_texture = None
         self._first_segment = 0
         self._last_segment = 0
-
-        self.destroyed.connect(
-            functools.partial(widget_destroyed, self.channels,
-                              weakref.ref(self))
-        )
 
         self.setLayout(QtWidgets.QVBoxLayout())
         self.scroll_area = QtWidgets.QScrollArea()


### PR DESCRIPTION
- Add filterable veto indicators to the Fast Faults tab
- Add veto indicators, veto conditions, and fault counters to the Arbiter Outputs tab.
- Remove redundant on-destroy cleanup steps (pydm handles this adequately by default)

There's going to need to be a follow-up for figuring out how to get vetoes onto the Preemptive Requests page. These mostly match their associated FFHWOs but have some exceptions and don't self-report the vetoes.

![image](https://github.com/pcdshub/pmps-ui/assets/10647860/392a1c7b-cbc0-4e3d-aac7-5b529614ce39)

![image](https://github.com/pcdshub/pmps-ui/assets/10647860/c7444f75-224c-487d-90cb-01b16a322d0d)
