### PR TITLE
REL/DOC: release notes v1.1.0

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@ Welcome to pmps-ui's documentation!
    :caption: Contents:
 
    upcoming_changes.rst
+   releases.rst
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -1,17 +1,13 @@
-107 doc_doc
-###########
+Release History
+###############
 
-API Breaks
-----------
-- N/A
+
+v1.1.0 (2024-02-20)
+===================
 
 Features
 --------
 - adds a splash screen to show loading progress during startup
-
-Bugfixes
---------
-- N/A
 
 Maintenance
 -----------


### PR DESCRIPTION
## Description
Release notes for v1.1.0

## Motivation and Context
We should do real release notes!  

Interestingly, git detected the deletion of the pre-release notes and addition of release.rst as the movement of the file, since they were nearly identical

## How Has This Been Tested?
make html

## Where Has This Been Documented?
this is docs

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
