### PR TITLE
MNT: minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,24 @@
 PMPS - User Interface
 =====================
 
-The main entry point for the PMPS UI is the `pmps.py` file.
-This display takes a macro called `CFG` which specify the prefix for the
-configuration file to be loaded, e.g. LFE_config.yml.
+The main entry point for the PMPS UI is simply the pmpsui module itself:
 
-By default to ensure backwards compatibility, if one launches the `pmps.py` file
-without specifying macros, the `LFE` configuration is loaded and the screen is
-launched.
-
-To launch a different configuration do:
-
-```bash
-pydm -m "CFG=KFE" pmps.py
 ```
+python -m pmpsui --help
+```
+
+This is typically launched for either LFE or KFE and with the
+web views disabled (since they are somewhere between adversely
+impacting performance and not working at all).
+
+```
+python -m pmpsui --area LFE --no-web
+```
+
+```
+python -m pmpsui --area KFE --no-web
+```
+
 
 Configuration File
 ==================

--- a/docs/source/upcoming_release_notes/115-misc.rst
+++ b/docs/source/upcoming_release_notes/115-misc.rst
@@ -1,0 +1,27 @@
+115 misc
+#################
+
+API Breaks
+----------
+- Delete the defunct symbolic link at the root of the repo.
+  Old scripts that launch using this are encouraged to either
+  swap to pmpsui/pmps.py or switch to the python -m pmpsui entrypoint.
+
+Features
+--------
+- Allow us to pass --area instead of --macros in pmpsui entrypoint
+
+Bugfixes
+--------
+- Update the outdated beam class table to version 1.6
+- Fix the broken --no-web arg on the pmpsui entrypoint
+- Fix an issue where a blank main windows would appear early and be confusing
+
+Maintenance
+-----------
+- Update the KFE configs from prod
+
+Contributors
+------------
+- ZLLentz
+- KaushikMalapati

--- a/launch.sh
+++ b/launch.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 config="${1}"
 shift
-pydm --hide-nav-bar --hide-status-bar -m "CFG=${config}" pmps.py $@
+python -m pmpsui --area "${config}" "$@"

--- a/launch.sh
+++ b/launch.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-config="${1}"
-shift
-python -m pmpsui --area "${config}" "$@"

--- a/pmps.py
+++ b/pmps.py
@@ -1,1 +1,0 @@
-pmpsui/pmps.py

--- a/pmpsui/main.py
+++ b/pmpsui/main.py
@@ -22,7 +22,7 @@ def make_parser():
         '--area',
         required=True,
         choices=("KFE", "LFE", "TST"),
-        help="Which area's faults to load"
+        help="Which area's configuration to load"
     )
 
     parser.add_argument(

--- a/pmpsui/main.py
+++ b/pmpsui/main.py
@@ -35,6 +35,21 @@ def make_parser():
     return parser
 
 
+class WindowStartsHiddenPyDMApplication(PyDMApplication):
+    """
+    Force the main window to stay hidden until after loading the GUI.
+
+    If not used, then we get a blank grey PyDMMainWindow during loads.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.main_window.show()
+
+    def make_main_window(self, *args, **kwargs):
+        super().make_main_window(*args, **kwargs)
+        self.main_window.hide()
+
+
 def main():
     """
     Mimics relevant portions of pydm_launcher.main, for bundling into pmpsui entrypoint
@@ -62,12 +77,11 @@ def main():
 
     # Here we supply the path to PyDMApplication, without doing this teardown
     # results in channel connection errors.  (create QApp, create display, exec)
-    qapp = PyDMApplication(
+    qapp = WindowStartsHiddenPyDMApplication(
         ui_file=Path(__file__).parent / 'pmps.py',
         command_line_args=cli_args,
         macros=macros,
         use_main_window=False,
         hide_nav_bar=True,
     )
-
     qapp.exec_()

--- a/pmpsui/main.py
+++ b/pmpsui/main.py
@@ -19,9 +19,10 @@ def make_parser():
     )
 
     parser.add_argument(
-        '--macro',
-        help=("Macro subsitution to use, in JSON object format.  Same as PyDM"
-              "macro substitution")
+        '--area',
+        required=True,
+        choices=("KFE", "LFE", "TST"),
+        help="Which area's faults to load"
     )
 
     parser.add_argument(
@@ -52,13 +53,12 @@ def main():
         logger.debug("QtWebEngine is not supported.")
     # end of pydm launcher vendoring
 
-    macros = None
-    if args.macro is not None:
-        macros = parse_macro_string(args.macro)
+
+    macros = parse_macro_string(f"CFG={args.area}")
 
     cli_args = ['--log_level', args.log_level]
     if args.no_web:
-        cli_args = ['--no_web'] + cli_args
+        cli_args = ['--no-web'] + cli_args
 
     # Here we supply the path to PyDMApplication, without doing this teardown
     # results in channel connection errors.  (create QApp, create display, exec)

--- a/pmpsui/pmps.py
+++ b/pmpsui/pmps.py
@@ -46,8 +46,6 @@ class PMPS(Display):
     new_mode_signal = QtCore.Signal(str)
 
     def __init__(self, parent=None, args=None, macros=None):
-        main_window = QApplication.instance().main_window
-        main_window.hide()
         # self.user_args = args
         # Assumes args are passed as list of [no_web, log_level] as in main.py
         self.splash: Optional[PMPSSplashScreen] = None
@@ -105,7 +103,6 @@ class PMPS(Display):
 
         self.splash.finish(self)
         self.splash = None
-        main_window.show()
 
     def setup_splash(self) -> None:
         pixmap = QPixmap(str(Path(__file__).parent.parent / 'pmps_splash.png'))

--- a/pmpsui/pmps.py
+++ b/pmpsui/pmps.py
@@ -46,6 +46,8 @@ class PMPS(Display):
     new_mode_signal = QtCore.Signal(str)
 
     def __init__(self, parent=None, args=None, macros=None):
+        main_window = QApplication.instance().main_window
+        main_window.hide()
         # self.user_args = args
         # Assumes args are passed as list of [no_web, log_level] as in main.py
         self.splash: Optional[PMPSSplashScreen] = None
@@ -103,6 +105,7 @@ class PMPS(Display):
 
         self.splash.finish(self)
         self.splash = None
+        main_window.show()
 
     def setup_splash(self) -> None:
         pixmap = QPixmap(str(Path(__file__).parent.parent / 'pmps_splash.png'))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

- Remove the symbolic link to the ui in the root of the repo because it doesn't work very well (no splash screen) and the vestigial `launch.sh` file that used it. Now there is one normal sanctioned way to launch the GUI (instead of at least three).
- Fix an issue where --no-web didn't work from the entrypoint (closes #113)
- Fix an issue where the pydm main window appeared too early (closes #114)
- Allow us to no longer pass pydm macros manually from the entrypoint (closes #104)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some nitpicks found while deploying the splash screen and recent updates to prod.

It's now possible/preferable to launch the app using:
```
python -m pmpsui --area LFE --no-web
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
PR text, pre-release notes, readme

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] ~New/changed functions and methods are covered in the test suite where possible~
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [ ] ~Test suite passes locally~
- [ ] ~Test suite passes on GitHub Actions~
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
