### PR TITLE
Increasing RIX motion PLC FFOs

### DIFF
--- a/pmpsui/configs/KFE_config.yml
+++ b/pmpsui/configs/KFE_config.yml
@@ -117,7 +117,7 @@ fastfaults:
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
-    ff_end: 200
+    ff_end: 210
 
   - name: "CRIX Vacuum"
     prefix: "PLC:CRIXS:VAC:"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Increasing FFOs for RIX motion PLC from 200 to 210 (after adding new solid-attenuator)

## Motivation and Context
https://github.com/pcdshub/lcls-plc-kfe-rix-motion/pull/88

## How Has This Been Tested?
Yes, deployed on PLC and pmps ui

## Where Has This Been Documented?
https://github.com/pcdshub/lcls-plc-kfe-rix-motion/pull/88

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
