### PR TITLE
adding new lfe motion arbiter and more fast faults

### DIFF
--- a/docs/source/upcoming_release_notes/118-lfe-motion-upgrade.rst
+++ b/docs/source/upcoming_release_notes/118-lfe-motion-upgrade.rst
@@ -1,0 +1,24 @@
+118 lfe-motion-upgrade
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Adding second arbiter to lfe-motion
+- Increasing the number of fast faults per ffo on lfe motion
+to 100 from 50 to match the plc
+
+Contributors
+------------
+- KaushikMalapati

--- a/pmpsui/configs/LFE_config.yml
+++ b/pmpsui/configs/LFE_config.yml
@@ -42,7 +42,7 @@ fastfaults:
     ffo_start: 1
     ffo_end: 2
     ff_start: 1
-    ff_end: 50
+    ff_end: 100
 
   - name: "LFE Optics"
     prefix: "PLC:LFE:OPTICS:"
@@ -70,7 +70,12 @@ preemptive_requests:
     assertion_pool_end: 20
 
   - prefix: "PLC:LFE:MOTION:"
-    arbiter_instance: "ARB"
+    arbiter_instance: "ARB:01"
+    assertion_pool_start: 1
+    assertion_pool_end: 20
+
+  - prefix: "PLC:LFE:MOTION:"
+    arbiter_instance: "ARB:02"
     assertion_pool_start: 1
     assertion_pool_end: 20
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Added a second arbiter for the L1 line 
- Increased the number of faults per output to 100

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Both of these changes were already made plc-side

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively
<img width="1816" height="302" alt="image" src="https://github.com/user-attachments/assets/dab3384e-a0de-473a-ad05-649e49078078" />
<img width="1845" height="358" alt="image" src="https://github.com/user-attachments/assets/7d0c7b28-58b6-4ead-b651-97b4e683b705" />


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
