### PR TITLE
FIX: increase K range on bar graph widgets for KFE

### DIFF
--- a/docs/source/upcoming_release_notes/124-fix_k_ranges.rst
+++ b/docs/source/upcoming_release_notes/124-fix_k_ranges.rst
@@ -1,0 +1,24 @@
+124 fix_k_ranges
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Set the maximum value on K bar indicators to the maximum K value as determined by PV.
+  Use the old hard-coded value of 6.0 as the default if the PV does not connect.
+  If the PV has a value less than 6.0, use 6.0 instead as the minimum allowable max K.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pmpsui/widgets.py
+++ b/pmpsui/widgets.py
@@ -14,8 +14,7 @@ from .tooltips import get_ev_range_tooltip, get_tooltip_for_bc_bitmask
 class UndulatorWidget(QtWidgets.QWidget, PyDMPrimitiveWidget):
     CHANNELS = dict(
         seed_number='ca://{prefix}PE:UND:SeedUndulatorNumber_RBV',
-        # upper_k='ca://{prefix}PE:UND:HiK_RBV', # Commented out. Requested to move to hardcoded value
-        # lower_k='ca://{prefix}PE:UND:LowK_RBV', # Commented out. Requested to move to hardcoded value
+        upper_k='ca://{prefix}PE:UND:HiK_RBV',
         active='ca://{prefix}PE:UND:{segment}:Active_RBV',
         curr_k='ca://{prefix}PE:UND:{segment}:KAct_RBV',
         target_k='ca://{prefix}PE:UND:{segment}:KDes_RBV',
@@ -186,9 +185,12 @@ class UndulatorWidget(QtWidgets.QWidget, PyDMPrimitiveWidget):
         painter.setPen(QtGui.QPen(QtCore.Qt.NoPen))
 
         active = self._values['active']
-        # upper_k = self._values['upper_k']
-        # lower_k = self._values['lower_k']
-        upper_k = 6.0
+        upper_k = self._values['upper_k']
+        if upper_k is None:
+            # e.g. if PV is not connected yet
+            upper_k = 6.0
+        else:
+            upper_k = max(6.0, upper_k)
         lower_k = 0.0
         curr_k = self._values['curr_k']
         target_k = self._values['target_k']


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Change the maximum k value on the bar graphs from a hard-coded 6.0 to whatever value is the maximum allowable K as determined by PV value.

If the PV does not connect, fall back to 6.0.
If the PV value is less than 6.0, enforce a minimum value of 6.0.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Maggie was asked to increase the KFE max K in https://jira.slac.stanford.edu/browse/ECS-9902

But, the new real K values are above the limits of the bar chart.
So, we have to make the bar chart longer.
But, if we set a new hard-coded value of 20.0, then the bars for the LFE line (which has a kmax under 3) become permanently too short.
And if we pick a value that isn't 20.0, it might confuse people into thinking we didn't actually increase the max to 20.0.
So, instead, we check the PV value for max K so we don't have to run different hard-coded values for each line (with associated config file updates).
But, this would change the LFE line's bar graphs from 6.0 down to 2.6 which might also confuse and worry people, thinking we made a change to the LFE PLC.
So this change (use PV, make sure it's at least 6.0) is a compromise.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only on both lines, but the code should look low-risk.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here and in https://jira.slac.stanford.edu/browse/ECS-9959

## Screenshots (if appropriate):
<img width="2650" height="1752" alt="image" src="https://github.com/user-attachments/assets/a64be0ad-9437-4128-9c79-7240206c8bfd" />


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] ~New/changed functions and methods are covered in the test suite where possible~
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [ ] ~Test suite passes locally~
- [ ] ~Test suite passes on GitHub Actions~
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
