### PR TITLE
FIX: hotfix some bad pydm widget behavior for pmps-ui

### DIFF
--- a/pmpsui/hotfix.py
+++ b/pmpsui/hotfix.py
@@ -1,0 +1,31 @@
+import logging
+
+from pydm.widgets.datetime import PyDMDateTimeEdit, TimeBase
+from qtpy import QtCore
+
+logger = logging.getLogger(__name__)
+
+
+def apply_hotfixes():
+    # Edge case: pydm v1.27.1 for Seconds mode (absolute set)
+    PyDMDateTimeEdit.send_value = hotfix_send_value
+
+
+def hotfix_send_value(self):
+    """Copy original and force result to int type"""
+    val = self.dateTime()
+    now = QtCore.QDateTime.currentDateTime()
+    if self._block_past_date and val < now:  # type: ignore
+        logger.error("Selected date cannot be lower than current date.")
+        return
+
+    if self.relative:
+        new_value = now.msecsTo(val)
+    else:
+        new_value = val.toMSecsSinceEpoch()
+    if self.timeBase == TimeBase.Seconds:
+        new_value /= 1000.0
+    # This is the hotfix line
+    new_value = int(new_value)
+    # This was the hotfix line
+    self.send_value_signal[int].emit(new_value)

--- a/pmpsui/pmps.py
+++ b/pmpsui/pmps.py
@@ -14,11 +14,14 @@ from qtpy.QtGui import QPixmap
 from qtpy.QtWidgets import QApplication
 
 from pmpsui.beamclass_table import install_bc_setText
+from pmpsui.hotfix import apply_hotfixes
 from pmpsui.splash import PMPSSplashScreen
 from pmpsui.tooltips import (get_mode_tooltip_lines, get_tooltip_for_bc,
                              setup_combobox_tooltip)
 from pmpsui.utils import BackCompat, morph_into_vertical
 from pmpsui.widgets import EvByteIndicator
+
+apply_hotfixes()
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Hotfix some odd behavior in the PyDMDateTimeEdit widget where with our settings, the results were seemingly random- and if the random result was in the past, the override controls would not work.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See https://github.com/slaclab/pydm/pull/1323 for more details of the related PR I submitted to PyDM.

This bug report came from TMO: https://jira.slac.stanford.edu/browse/ECS-10112

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively in TMO using some dummy faults
Interactively using a dummy tiny screen with dummy PVs
The PyDM PR has a test

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here and in the PyDM PR

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] ~New/changed functions and methods are covered in the test suite where possible~
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [ ] ~Test suite passes locally~
- [ ] ~Test suite passes on GitHub Actions~
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
