### PR TITLE
Filtering vetoed faults by default

### DIFF
--- a/docs/source/upcoming_release_notes/126-filter-vetoed-ffs.rst
+++ b/docs/source/upcoming_release_notes/126-filter-vetoed-ffs.rst
@@ -1,0 +1,22 @@
+126 filter-vetoed-ffs
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Changed the veto filter checkbox to be true by default, so new screens will hide vetoed fast faults.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- KaushikMalapati

--- a/pmpsui/ui/fast_faults.ui
+++ b/pmpsui/ui/fast_faults.ui
@@ -206,7 +206,7 @@
             <bool>true</bool>
            </property>
            <property name="checked">
-            <bool>false</bool>
+            <bool>true</bool>
            </property>
            <layout class="QHBoxLayout" name="horizontalLayout_9">
             <property name="spacing">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Set the veto filter for fast faults to true so upon opening the screen, vetoed fast faults will be hidden by default unless the user disables/changes that filter

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-10446

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively. You will have to believe me that this screenshot was taken right after the screen opened and I did not check the filter manually
<img width="1888" height="968" alt="image" src="https://github.com/user-attachments/assets/3ac5757f-b64b-4986-9f1b-de147cd50140" />

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
